### PR TITLE
Allow to pass nil value to DateTime field

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/oid/date_time.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/date_time.rb
@@ -8,6 +8,7 @@ module ActiveRecord
 
           def serialize(value)
             value = super
+            return unless value
             return value.strftime('%Y-%m-%d %H:%M:%S') unless value.acts_like?(:time)
 
             value.to_time.strftime('%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
The DateTime OID calls `strftime` method on DateTime value in case if the value does not act like time. The problem is that `nil` does not act like time and doesn't have `strftime` method so that creating an object with `{ ... datetime_field: nil, ... }` leads to exception.