### PR TITLE
Renamed duplicated option 'replica' for Rails 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ default: &default
   debug: true # use for showing in to log technical information
   migrations_paths: db/clickhouse # optional, default: db/migrate_clickhouse
   cluster: 'cluster_name' # optional for creating tables in cluster 
-  replica: '{shard}' # optional for creating system tables for shards
+  clickhouse_replica: '{shard}' # optional for creating system tables for shards
 ```
 
 ## Usage in Rails 5

--- a/lib/tasks/clickhouse.rake
+++ b/lib/tasks/clickhouse.rake
@@ -3,7 +3,7 @@
 namespace :clickhouse do
 
   task prepare_schema_migration_table: :environment do
-    cluster, database, replica = ActiveRecord::Base.connection_config.values_at(:cluster, :database, :replica)
+    cluster, database, replica = ActiveRecord::Base.connection_config.values_at(:cluster, :database, :clickhouse_replica)
     return if cluster.nil?
 
     connection = ActiveRecord::Base.connection
@@ -34,7 +34,7 @@ namespace :clickhouse do
   end
 
   task prepare_internal_metadata_table: :environment do
-    cluster, database, replica = ActiveRecord::Base.connection_config.values_at(:cluster, :database, :replica)
+    cluster, database, replica = ActiveRecord::Base.connection_config.values_at(:cluster, :database, :clickhouse_replica)
     return if cluster.nil?
 
     connection = ActiveRecord::Base.connection


### PR DESCRIPTION
`replica` option was added to the Rails 6 configuration.

So it conflicts with the clickhouse option `replica`.