### PR TITLE
Adding support for all integer types through :limit and :unsigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,44 @@ ActionView.maximum(:date)
 #=> 'Wed, 29 Nov 2017'
 ```
 
+
+### Migration Data Types
+
+Integer types are unsigned by default. Specify signed values with `:unsigned =>
+false`. The default integer is `UInt32`
+
+| Type (bit size)    | Range | :limit (byte size) |
+| :---        |    :----:   |          ---: |
+| Int8 | -128 to 127 | limit: 1 | 
+| Int16 | -32768 to 32767 | 2 |
+| Int32 | -2147483648 to 2,147,483,647 | 3, 4 |
+| Int64 | -9223372036854775808 to 9223372036854775807] |  5,6,7, 8 |
+| Int128 | ... | 9 - 15 |
+| Int256 | ... | 16+ |
+| UInt8 | 0 to 255 | 1 |
+| UInt16 | 0 to 65,535 | 2 |
+| UInt32 | 0 to 4,294,967,295 | 3,4 |
+| UInt64 | 0 to 18446744073709551615 | 5,6,7,8 |
+| UInt256 | 0 to ... | 8+ |
+
+Example:
+
+``` ruby
+class CreateDataItems < ActiveRecord::Migration
+  def change
+    create_table "data_items", id: false, options: "VersionedCollapsingMergeTree(sign, version) PARTITION BY toYYYYMM(day) ORDER BY category", force: :cascade do |t|
+      t.date "day", null: false
+      t.string "category", null: false
+      t.integer "value_in", null: false
+      t.integer "sign", limit: 1, unsigned: false, default: -> { "CAST(1, 'Int8')" }, null: false
+      t.integer "version", limit: 8, default: -> { "CAST(toUnixTimestamp(now()), 'UInt64')" }, null: false
+    end
+  end
+end
+      
+```
+
+
 ### Using replica and cluster params in connection parameters
 
 ```yml

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -79,7 +79,6 @@ module ActiveRecord
 
     class ClickhouseAdapter < AbstractAdapter
       ADAPTER_NAME = 'Clickhouse'.freeze
-
       NATIVE_DATABASE_TYPES = {
         string: { name: 'String' },
         integer: { name: 'UInt32' },
@@ -88,7 +87,21 @@ module ActiveRecord
         decimal: { name: 'Decimal' },
         datetime: { name: 'DateTime' },
         date: { name: 'Date' },
-        boolean: { name: 'UInt8' }
+        boolean: { name: 'UInt8' },
+                               
+        int8:  { name: 'Int8' },
+        int16: { name: 'Int16' },
+        int32: { name: 'Int32' },
+        int64:  { name: 'Int64' },
+        int128: { name: 'Int128' },
+        int256: { name: 'Int256' },
+
+        uint8: { name: 'UInt8' },
+        uint16: { name: 'UInt16' },
+        uint32: { name: 'UInt32' },
+        uint64: { name: 'UInt64' },
+        # uint128: { name: 'UInt128' }, not yet implemented in clickhouse
+        uint256: { name: 'UInt256' },
       }.freeze
 
       include Clickhouse::SchemaStatements
@@ -154,14 +167,25 @@ module ActiveRecord
         register_class_with_limit m, %r(String), Type::String
         register_class_with_limit m, 'Date',  Clickhouse::OID::Date
         register_class_with_limit m, 'DateTime',  Clickhouse::OID::DateTime
-        register_class_with_limit m, %r(Uint8), Type::UnsignedInteger
-        m.alias_type 'UInt16', 'UInt8'
-        m.alias_type 'UInt32', 'UInt8'
-        register_class_with_limit m, %r(UInt64), Type::UnsignedInteger
+        
         register_class_with_limit m, %r(Int8), Type::Integer
+        register_class_with_limit m, %r(Int16), Type::Integer
+        register_class_with_limit m, %r(Int32), Type::Integer
+        register_class_with_limit m, %r(Int64), Type::Integer
+        register_class_with_limit m, %r(Int128), Type::Integer
+        register_class_with_limit m, %r(Int256), Type::Integer
+        
+        register_class_with_limit m, %r(Uint8), Type::UnsignedInteger
+        register_class_with_limit m, %r(UInt16), Type::UnsignedInteger
+        register_class_with_limit m, %r(UInt32), Type::UnsignedInteger
+        register_class_with_limit m, %r(UInt64), Type::UnsignedInteger
+        #register_class_with_limit m, %r(UInt128), Type::UnsignedInteger #not implemnted in clickhouse
+        register_class_with_limit m, %r(UInt256), Type::UnsignedInteger
+
         m.alias_type 'Int16', 'Int8'
         m.alias_type 'Int32', 'Int8'
-        register_class_with_limit m, %r(Int64), Type::Integer
+        m.alias_type 'UInt16', 'UInt8'
+        m.alias_type 'UInt32', 'UInt8'
       end
 
       # Quoting time without microseconds


### PR DESCRIPTION
I was using `ENGINE = VersionedCollapsingMergeTree(sign, version)` but when trying to load the schema file, it would raise an exception because `sign` must be an an `Int8`. This adds support for specifying the integer size with `:limit` and signed/unsigned with `:unsigned => false`. These details are explained in the README patch.

This does not fix the fact that the schema file was probably dumped wrong. I'm not sure where to look to fix that issue. I had originally created the tables with an `execute("CREATE TABLE ...")` migration - maybe part of the problem.