### PR TITLE
fixed ruby 2.7+ keyword arguments passing

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_definitions.rb
@@ -58,7 +58,7 @@ module ActiveRecord
               kind = :int256     if options[:limit] > 16
             end
           end
-          args.each { |name| column(name, kind, options.except(:limit, :unsigned)) }
+          args.each { |name| column(name, kind, **options.except(:limit, :unsigned)) }
         end
       end
     end


### PR DESCRIPTION
Hi.
Thirst of all, thanks a lot for the gem.
 
But there's an issue with keywords arguments passing that leads to
```
ArgumentError: wrong number of arguments (given 3, expected 2)
/home/orlylabs/rails-app/vendor/bundle/ruby/3.0.1/gems/activerecord-6.1.3.2/lib/active_record/connection_adapters/abstract/schema_definitions.rb:401:in `column'
/home/orlylabs/rails-app/vendor/bundle/ruby/3.0.1/bundler/gems/clickhouse-activerecord-0c8e5aac5eee/lib/active_record/connection_adapters/clickhouse/schema_definitions.rb:61:in `block in integer'
```

So there's a small fix you may consider. Thanks