### PR TITLE
Extend Views support.

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -37,7 +37,9 @@ module ActiveRecord
             opts ||= options.options
           end
   
-          is_view = create_sql.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/)
+          is_view = create_sql.match(/^CREATE\s+((MATERIALIZED|LIVE)\s+)?VIEW/)
+          if opts.present? && is_view && create_sql.match(/^CREATE\s+LIVE\s+VIEW\s+/)
+            create_sql.replace(opts)
           if opts.present? && is_view && !create_sql.match(/^CREATE\s+MATERIALIZED\s+/)
             create_sql << opts
           elsif opts.present? && is_view && opts.match(/(^|\s)TO\s+/)
@@ -66,8 +68,9 @@ module ActiveRecord
 
         # Returns any SQL string to go between CREATE and TABLE. May be nil.
         def table_modifier_in_create(o)
-          " TEMPORARY" if o.temporary
-          " MATERIALIZED" if o.materialized
+          return " TEMPORARY" if o.temporary
+          return " MATERIALIZED" if o.materialized
+          return " LIVE" if o.live
         end
 
         def visit_ChangeColumnDefinition(o)

--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -30,9 +30,9 @@ module ActiveRecord
           sql
         end
 
-        def add_table_options!(create_sql, options)
+        def add_table_options!(create_sql, options, view, materialized)
           opts = options[:options]
-          if options.respond_to?(:options)
+          if options.respond_to?(:options) && view.present? && materialized.blank?
             # rails 6.1
             opts ||= options.options
           end
@@ -54,8 +54,7 @@ module ActiveRecord
           statements = o.columns.map { |c| accept c }
           statements << accept(o.primary_keys) if o.primary_keys
           create_sql << "(#{statements.join(', ')})" if statements.present?
-          # Attach options for only table or materialized view
-          add_table_options!(create_sql, o)  if !o.view || o.view && o.materialized
+          add_table_options!(create_sql, table_options(o), o.view, o.materialized)
           create_sql << " AS #{to_sql(o.as)}" if o.as
           create_sql
         end

--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -40,7 +40,7 @@ module ActiveRecord
           is_view = create_sql.match(/^CREATE\s+((MATERIALIZED|LIVE)\s+)?VIEW/)
           if opts.present? && is_view && create_sql.match(/^CREATE\s+LIVE\s+VIEW\s+/)
             create_sql.replace(opts)
-          if opts.present? && is_view && !create_sql.match(/^CREATE\s+MATERIALIZED\s+/)
+          elsif opts.present? && is_view && !create_sql.match(/^CREATE\s+MATERIALIZED\s+/)
             create_sql << opts
           elsif opts.present? && is_view && opts.match(/(^|\s)TO\s+/)
             create_sql << "TO #{opts.gsub(/^(?:.*?) TO (.*?)$/, '\\1')}"

--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -61,7 +61,7 @@ module ActiveRecord
           statements = o.columns.map { |c| accept c }
           statements << accept(o.primary_keys) if o.primary_keys
           create_sql << "(#{statements.join(', ')})" if statements.present?
-          add_table_options!(create_sql, table_options(o))
+          add_table_options!(create_sql, o)
           create_sql << " AS #{to_sql(o.as)}" if o.as
           create_sql
         end

--- a/lib/active_record/connection_adapters/clickhouse/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_definitions.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module Clickhouse
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
 
-        attr_reader :view, :materialized, :if_not_exists
+        attr_reader :view, :materialized, :live, :if_not_exists
 
         def initialize(
             conn,
@@ -17,6 +17,7 @@ module ActiveRecord
             comment: nil,
             view: false,
             materialized: false,
+            live: false,
             **
           )
           @conn = conn
@@ -30,8 +31,9 @@ module ActiveRecord
           @as = as
           @name = name
           @comment = comment
-          @view = view || materialized
+          @view = view || materialized || live
           @materialized = materialized
+          @live = live
         end
 
         def integer(*args, **options)

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -44,6 +44,8 @@ module ActiveRecord
 
         def table_options(table)
           sql = show_create_table(table)
+          return { options: "AS SELECT #{sql.gsub(/^(?:.*?) AS SELECT (.*?)$/, '\\1')}" } if sql.match(/^CREATE\sVIEW/)
+
           { options: sql.gsub(/^(?:.*?)(?:ENGINE = (.*?))?( AS SELECT .*?)?$/, '\\1').presence, as: sql.match(/^CREATE (?:.*?) AS (SELECT .*?)$/).try(:[], 1) }.compact
         end
 

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -118,7 +118,7 @@ module ActiveRecord
         uint16: { name: 'UInt16' },
         uint32: { name: 'UInt32' },
         uint64: { name: 'UInt64' },
-        # uint128: { name: 'UInt128' }, not yet implemented in clickhouse
+        # UInt128 is not supported yet
         uint256: { name: 'UInt256' },
       }.freeze
 

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -34,8 +34,13 @@ HEADER
     end
 
     def tables(stream)
-      sorted_tables = @connection.tables.sort {|a,b| @connection.show_create_table(a).match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) ? 1 : a <=> b }
-
+      sorted_tables = @connection.tables.sort do |a,b|
+        if @connection.show_create_table(a).match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/)
+          @connection.show_create_table(b).match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) ? a <=> b : 1
+        else
+          @connection.show_create_table(b).match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) ? -1 : a <=> b
+        end
+      end
       sorted_tables.each do |table_name|
         table(table_name, stream) unless ignored?(table_name)
       end


### PR DESCRIPTION
Using the migration will be possibile to create:

1. Normal views (not Materialized)
2. Live Views
3. Materialized Views used as consumers Ex:  ( `CREATE MATERIALIZED VIEW consumer TO destination AS SELECT ... FROM source`)