### PR TITLE
Fix schema load failure due to INSERT statements

### DIFF
--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -43,7 +43,15 @@ module ClickhouseActiverecord
     end
 
     def structure_load(*args)
-      File.read(args.first).split(";\n\n").each { |sql| connection.execute(sql) }
+      File.read(args.first).split(";\n\n").each do |sql|
+        if sql.gsub(/[a-z]/i, '').blank?
+          next
+        elsif sql =~ /^INSERT INTO/
+          connection.do_execute(sql, nil, format: nil)
+        else
+          connection.execute(sql)
+        end
+      end
     end
 
     def migrate


### PR DESCRIPTION
Schema / structure loads includes `INSERT` statements, which would previously fail as it would put `FORMAT JSONCompact` on the end.

This PR special cases `INSERT` statements, and ignores the empty queries.