### PR TITLE
Various compatibility fixes

### DIFF
--- a/clickhouse-activerecord.gemspec
+++ b/clickhouse-activerecord.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'bundler', '>= 1.13.4'
   spec.add_runtime_dependency 'activerecord', '>= 5.2'
 
-  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'bundler', '>= 1.15'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.4'
   spec.add_development_dependency 'pry', '~> 0.12'

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -39,7 +39,7 @@ module ActiveRecord
         end
 
         def tables(name = nil)
-          result = do_system_execute('SHOW TABLES', name)
+          result = do_system_execute("SHOW TABLES WHERE name NOT LIKE '.inner_id.%'", name)
           return [] if result.nil?
           result['data'].flatten
         end

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -80,13 +80,19 @@ module ActiveRecord
       def is_view=(value)
         @is_view = value
       end
-
-      def arel_table # :nodoc:
-        @arel_table ||= ClickhouseActiverecord::Arel::Table.new(table_name, type_caster: type_caster)
-      end
-
     end
-   end
+  end
+
+  ActiveRecord::Core::ClassMethods.module_eval do
+    def arel_table
+      @arel_table ||=
+        if self.connection.is_a?(ConnectionAdapters::ClickhouseAdapter)
+          ClickhouseActiverecord::Arel::Table.new(table_name, type_caster: type_caster)
+        else
+          Arel::Table.new(table_name, klass: self)
+        end
+    end
+  end
 
   module ConnectionAdapters
     class ClickhouseColumn < Column


### PR DESCRIPTION
Hi!  My team and I use this gem quite a bit and would love to share some contributions we've made.  This PR contains a handful of small changes that we've made to integrate it with our existing codebases.  I'm happy to split this up into multiple PRs if you feel the changes are too disparate, but we thought they were small enough that they could go together.

## Table dump
- Filters out Clickhouse-internal matviews that are normally exported, which start with `.inner_id.`

## Do not globally override AR
- `reverse_order!` has been rewritten with a `prepend` to leverage `super`, instead of copying and pasting any changes to the method in future AR versions.
- `arel_table` only returns a `ClickhouseActiverecord::Arel::Table` if the model uses Clickhouse, which is necessary if Clickhouse is only one of multiple databases in use.
- Another PR we'll submit later includes some further refactorings in the same vein, moving code around to prevent wholesale replacement of AR code with Clickhouse-specific behavior and to otherwise make Clickhouse-specific code play more nicely with AR in the future.

## Bundler version bump
- Allow newer versions of Bundler