### PR TITLE
Fix precision and scale extraction of decimal fields

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -191,6 +191,20 @@ module ActiveRecord
         end
       end
 
+      # `extract_scale` and `extract_precision` are the same as in the Rails abstract base class,
+      # except this permits a space after the comma
+
+      def extract_scale(sql_type)
+        case sql_type
+        when /\((\d+)\)/ then 0
+        when /\((\d+)(,\s?(\d+))\)/ then $3.to_i
+        end
+      end
+
+      def extract_precision(sql_type)
+        $1.to_i if sql_type =~ /\((\d+)(,\s?\d+)?\)/
+      end
+
       def initialize_type_map(m) # :nodoc:
         super
         register_class_with_limit m, %r(String), Type::String


### PR DESCRIPTION
`rake db:schema:dump:clickhouse` doesn't record the precision and scale of `Decimal` columns. For example, instead of the expected:
``` rb
  t.decimal "my_decimal_column", precision: 14, scale: 2
```
it just stores:
``` rb
  t.decimal "my_decimal_column"
```

I did quite a bit of digging and figured out that this is because the Rails schema dumper—the default one—doesn't permit spaces after commas in _e.g._ `Decimal(14, 2)`, and ClickHouse dumps the schema with this space. So this PR overrides the relevant methods to permit this space.

The methods that this overrides are in:
https://github.com/rails/rails/blob/4d5a570cfe1890f71a1d198a5fe40d528f2b60d4/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L770-L779
``` rb
          def extract_scale(sql_type)
            case sql_type
            when /\((\d+)\)/ then 0
            when /\((\d+)(,(\d+))\)/ then $3.to_i
            end
          end


          def extract_precision(sql_type)
            $1.to_i if sql_type =~ /\((\d+)(,\d+)?\)/
          end
```
The only difference is the addition of `\s?` after the commas in the regexes.