### PR TITLE
Use ClickHouse default KeepAlive timeout of 10 seconds

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -31,7 +31,8 @@ module ActiveRecord
             ssl: config[:ssl].present? ? config[:ssl] : port == 443,
             sslca: config[:sslca],
             read_timeout: config[:read_timeout],
-            write_timeout: config[:write_timeout],
+            write_timeout: config[:write_timeout], 
+            keep_alive_timeout: config[:keep_alive_timeout]
           }
         end
 
@@ -417,7 +418,10 @@ module ActiveRecord
         @connection.ca_file = @connection_parameters[:ca_file] if @connection_parameters[:ca_file]
         @connection.read_timeout = @connection_parameters[:read_timeout] if @connection_parameters[:read_timeout]
         @connection.write_timeout = @connection_parameters[:write_timeout] if @connection_parameters[:write_timeout]
-
+        
+        # Use clickhouse default keep_alive_timeout value of 10, rather than Net::HTTP's default of 2
+        @connection.keep_alive_timeout = @connection_parameters[:keep_alive_timeout] || 10
+        
         @connection
       end
 


### PR DESCRIPTION
Net::HTTP defaults to 2 seconds, which is much shorter than ClickHouse's
10 seconds.

Ideally we should respect the Keep-Alive response header, but that
responsibility should be handled by the HTTP transport, and it's a
limitation of Net::HTTP's implementation - net-http-persistent has code
to handle this as an example.