### PR TITLE
Fixes to create_table method

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -376,7 +376,7 @@ module ActiveRecord
 
       def database_engine_atomic?
         current_database_engine = "select engine from system.databases where name = '#{@config[:database]}'"
-        res = ActiveRecord::Base.connection.select_one(current_database_engine)
+        res = select_one(current_database_engine)
         res['engine'] == 'Atomic' if res
       end
 

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -304,7 +304,7 @@ module ActiveRecord
           drop_table(table_name, options.merge(if_exists: true))
         end
 
-        execute schema_creation.accept td
+        do_execute(schema_creation.accept(td), format: nil)
 
         if options[:with_distributed]
           distributed_table_name = options.delete(:with_distributed)


### PR DESCRIPTION
These are a couple of changes I needed to make in order to get the `connection.create_table` method to work.

The symptoms are:
- For 481598a, it was trying to send the `select engine from system.databases` query to Postgres, presumably because it's our primary database. My guess is this line accidentally assumed that ClickHouse is the primary database, which for us isn't the case. This just drops the `ActiveRecord::Base.connection` so that it will use the `select_one` from the same `ClickhouseAdapter`.
- For 67390f9, it was trying to add `FORMAT JSONCompact` to the `CREATE TABLE` query, which is a syntax error.

We're on Ruby 3.0.4, Rails 6.1.4.4, ClickHouse 21.8.14.5. Open to feedback on making this more robust.