### PR TITLE
Possibility to use an alias in cluster name

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -383,7 +383,13 @@ module ActiveRecord
       end
 
       def apply_cluster(sql)
-        cluster ? "#{sql} ON CLUSTER #{cluster}" : sql
+        if cluster
+          normalized_cluster_name = cluster.start_with?('{') ? "'#{cluster}'" : cluster
+
+          "#{sql} ON CLUSTER #{normalized_cluster_name}"
+        else
+          sql
+        end
       end
 
       def supports_insert_on_duplicate_skip?

--- a/spec/cases/migration_spec.rb
+++ b/spec/cases/migration_spec.rb
@@ -224,6 +224,47 @@ RSpec.describe 'Migration', :migrations do
           end
         end
       end
+
+      context 'with alias in cluster_name' do
+        let(:model) do
+          Class.new(ActiveRecord::Base) do
+            self.table_name = 'some'
+          end
+        end
+        connection_config = ActiveRecord::Base.connection_db_config.configuration_hash
+
+        before(:all) do
+          ActiveRecord::Base.establish_connection(connection_config.merge(cluster_name: '{cluster}'))
+        end
+
+        after(:all) do
+          ActiveRecord::Base.establish_connection(connection_config)
+        end
+
+        it 'creates a table' do
+          migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'dsl_create_table_with_cluster_name_alias')
+          quietly { ActiveRecord::MigrationContext.new(migrations_dir, ClickhouseActiverecord::SchemaMigration).up }
+
+          current_schema = schema(model)
+
+          expect(current_schema.keys.count).to eq(1)
+          expect(current_schema).to have_key('date')
+          expect(current_schema['date'].sql_type).to eq('Date')
+        end
+
+        it 'drops a table' do
+          migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'dsl_create_table_with_cluster_name_alias')
+          quietly { ActiveRecord::MigrationContext.new(migrations_dir, ClickhouseActiverecord::SchemaMigration).up }
+
+          expect(ActiveRecord::Base.connection.tables).to include('some')
+
+          quietly do
+            ClickhouseActiverecord::MigrationContext.new(migrations_dir, ClickhouseActiverecord::SchemaMigration).down
+          end
+
+          expect(ActiveRecord::Base.connection.tables).not_to include('some')
+        end
+      end
     end
 
     describe 'drop table' do

--- a/spec/fixtures/migrations/dsl_create_table_with_cluster_name_alias/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_create_table_with_cluster_name_alias/1_create_some_table.rb
@@ -1,0 +1,7 @@
+class CreateSomeTable < ActiveRecord::Migration[5.0]
+  def change
+    create_table :some, options: 'MergeTree(date, (date), 8192)' do |t|
+      t.date :date, null: false
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,9 +53,11 @@ def schema(model)
 end
 
 def clear_db
-  current_cluster_name = ActiveRecord::Base.connection_db_config.configuration_hash[:cluster_name]
-  pattern = if current_cluster_name
-              "DROP TABLE %s ON CLUSTER #{current_cluster_name}"
+  cluster = ActiveRecord::Base.connection_db_config.configuration_hash[:cluster_name]
+  pattern = if cluster
+              normalized_cluster_name = cluster.start_with?('{') ? "'#{cluster}'" : cluster
+
+              "DROP TABLE %s ON CLUSTER #{normalized_cluster_name}"
             else
               'DROP TABLE %s'
             end


### PR DESCRIPTION
Hello!
I tried to use an alias in `cluster_name` with config:
```yaml
...
cluster_name: '{cluster}'
replica_name: '{replica}'
...
```
But I got an error on database creation:
```
Code: 62. DB::Exception: Syntax error: failed at position 47 ('{'): {cluster}. Expected one of identifier, string literal. (SYNTAX_ERROR) (version 22.5.2.53 (official build))
```
I found a workaround:
```yaml
...
cluster_name: "'{cluster}'"
replica_name: '{replica}'
...
```
It works for database creation, but it doesn't for replicated tables because of interpolation: https://github.com/PNixx/clickhouse-activerecord/blob/c2a4f86f35974f5993be1711d930379442b9ad23/lib/active_record/connection_adapters/clickhouse_adapter.rb#L376

Here's a small pull request. It allows to do:
```yaml
...
cluster_name: '{cluster}'
replica_name: '{replica}'
...
```

I hope you will accept it.