### PR TITLE
Fix error on schema_migrations table when more then 100 migrations

### DIFF
--- a/lib/clickhouse-activerecord/migration.rb
+++ b/lib/clickhouse-activerecord/migration.rb
@@ -10,7 +10,7 @@ module ClickhouseActiverecord
 
         version_options = connection.internal_string_options_for_primary_key
         table_options = {
-          id: false, options: 'ReplacingMergeTree(ver) PARTITION BY version ORDER BY (version)', if_not_exists: true
+          id: false, options: 'ReplacingMergeTree(ver) ORDER BY (version)', if_not_exists: true
         }
         full_config = connection.instance_variable_get(:@full_config) || {}
 


### PR DESCRIPTION
This PR fixing issue #75 :

Current schema_migrations table structure is:
```
CREATE TABLE schema_migrations
(
    `version` String,
    `active` Int8 DEFAULT 1,
    `ver` DateTime DEFAULT now()
)
ENGINE = ReplacingMergeTree(ver)
PARTITION BY version
ORDER BY version
SETTINGS index_granularity = 8192;
```
So it will create 1 partition for each version. Default value for max_partitions_per_insert_block is 100, and actually it's bad to have too many partitions, so it's better to remove PARTITION BY from schema_migrations table definition.

Other wise if you have more then 100 migrations and try to do db:structure:load
You will got:
```
ActiveRecord::ActiveRecordError: Response code: 500:
Code: 252. DB::Exception: Too many partitions for single INSERT block (more than 100). The limit is controlled by 'max_partitions_per_insert_block' setting. Large number of partitions is a common misconception. It will lead to severe negative performance impact, including slow server startup, slow INSERT queries and slow SELECT queries. Recommended total number of partitions for a table is under 1000..10000. Please note, that partitioning is not intended to speed up SELECT queries (ORDER BY key is sufficient to make range queries fast). Partitions are intended for data manipulation (DROP PARTITION, etc). 
```