### PR TITLE
Hotfix/ruby3 named params

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -108,7 +108,7 @@ module ActiveRecord
 
         def visit_ChangeColumnDefinition(o)
           column = o.column
-          column.sql_type = type_to_sql(column.type, column.options)
+          column.sql_type = type_to_sql(column.type, **column.options)
           options = column_options(column)
 
           quoted_column_name = quote_column_name(o.name)

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -11,6 +11,7 @@ require 'active_record/connection_adapters/clickhouse/schema_definitions'
 require 'active_record/connection_adapters/clickhouse/schema_creation'
 require 'active_record/connection_adapters/clickhouse/schema_statements'
 require 'net/http'
+require 'openssl'
 
 module ActiveRecord
   class Base

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -425,7 +425,7 @@ module ActiveRecord
 
       def change_column_for_alter(table_name, column_name, type, options = {})
         td = create_table_definition(table_name)
-        cd = td.new_column_definition(column_name, type, options)
+        cd = td.new_column_definition(column_name, type, **options)
         schema_creation.accept(ChangeColumnDefinition.new(cd, column_name))
       end
 


### PR DESCRIPTION
fixed error "wrong number of arguments (given 3, expected 2)" for Ruby3.1.3, rails 6.1.
