### PR TITLE
Add support for HTTP specific settings.

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -34,8 +34,9 @@ module ActiveRecord
           raise ActiveRecord::ActiveRecordError, 'Clickhouse update is not supported'
         end
 
-        def exec_delete(_sql, _name = nil, _binds = [])
-          raise ActiveRecord::ActiveRecordError, 'Clickhouse delete is not supported'
+        def exec_delete(sql, name = nil, _binds = [])
+          do_execute(sql, name, format: nil)
+          true
         end
 
         def tables(name = nil)

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -42,8 +42,13 @@ module ActiveRecord
         else
           raise ArgumentError, 'No database specified. Missing argument: database.'
         end
+        
+        config_params = { user: config[:username], password: config[:password], database: database }
 
-        ConnectionAdapters::ClickhouseAdapter.new(logger, connection, { user: config[:username], password: config[:password], database: database }.compact, config)
+        # Settings specific to the Clickhouse HTTP Protocol.
+        config_params.merge!(config[:http])
+
+        ConnectionAdapters::ClickhouseAdapter.new(logger, connection, config_params.compact, config)
       end
     end
   end


### PR DESCRIPTION
I have the need to pass in HTTP timeout settings besides the ActiveRecord socket timeouts. This allows you to pass any of the available HTTP settings on every request.