### PR TITLE
add "SYNC" keyword support for "DROP TABLE"

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -334,7 +334,13 @@ module ActiveRecord
       end
 
       def drop_table(table_name, options = {}) # :nodoc:
-        do_execute apply_cluster "DROP TABLE#{' IF EXISTS' if options[:if_exists]} #{quote_table_name(table_name)}"
+        query = "DROP TABLE"
+        query = "#{query} IF EXISTS " if options[:if_exists]
+        query = "#{query} #{quote_table_name(table_name)}"
+        query = apply_cluster(query)
+        query = "#{query} SYNC" if options[:sync]
+
+        do_execute(query)
 
         if options[:with_distributed]
           distributed_table_name = options.delete(:with_distributed)

--- a/spec/cases/migration_spec.rb
+++ b/spec/cases/migration_spec.rb
@@ -304,6 +304,17 @@ RSpec.describe 'Migration', :migrations do
       end
     end
 
+    describe 'drop table sync' do
+      migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'dsl_drop_table_sync')
+      quietly { ClickhouseActiverecord::MigrationContext.new(migrations_dir, model.connection.schema_migration).up(1) }
+
+      expect(ActiveRecord::Base.connection.tables).to include('some')
+
+      quietly { ClickhouseActiverecord::MigrationContext.new(migrations_dir, model.connection.schema_migration).up(2) }
+
+      expect(ActiveRecord::Base.connection.tables).not_to include('some')
+    end
+
     describe 'add column' do
       it 'adds a new column' do
         migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'dsl_add_column')

--- a/spec/fixtures/migrations/dsl_drop_table_sync/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_drop_table_sync/1_create_some_table.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateSomeTable < ActiveRecord::Migration[5.0]
+  def up
+    create_table :some, options: 'MergeTree PARTITION BY toYYYYMM(date) ORDER BY (date)' do |t|
+      t.date :date, null: false
+    end
+  end
+end
+

--- a/spec/fixtures/migrations/dsl_drop_table_sync/2_drop_some_table.rb
+++ b/spec/fixtures/migrations/dsl_drop_table_sync/2_drop_some_table.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class DropSomeTable < ActiveRecord::Migration[5.0]
+  def up
+    drop_table :some, sync: true
+  end
+end
+


### PR DESCRIPTION
Hello!

Right now, it's impossible to use the "SYNC" keyword for "DROP TABLE". This PR adds this possibility.

Documentation: https://clickhouse.com/docs/en/sql-reference/statements/drop

```
If the SYNC modifier is specified, the entity is dropped without delay.
``` 