### PR TITLE
Backport UUID column support

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/oid/uuid.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/uuid.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module Clickhouse
+      module OID # :nodoc:
+        class Uuid < Type::Value # :nodoc:
+          ACCEPTABLE_UUID = %r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}
+
+          alias :serialize :deserialize
+
+          def type
+            :uuid
+          end
+
+          def changed?(old_value, new_value, _)
+            old_value.class != new_value.class ||
+              new_value && old_value.casecmp(new_value) != 0
+          end
+
+          def changed_in_place?(raw_old_value, new_value)
+            raw_old_value.class != new_value.class ||
+              new_value && raw_old_value.casecmp(new_value) != 0
+          end
+
+          private
+
+          def cast_value(value)
+            casted = value.to_s
+            casted if casted.match?(ACCEPTABLE_UUID)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -7,6 +7,7 @@ require 'clickhouse-activerecord/migration'
 require 'active_record/connection_adapters/clickhouse/oid/array'
 require 'active_record/connection_adapters/clickhouse/oid/date'
 require 'active_record/connection_adapters/clickhouse/oid/date_time'
+require 'active_record/connection_adapters/clickhouse/oid/uuid'
 require 'active_record/connection_adapters/clickhouse/oid/big_integer'
 require 'active_record/connection_adapters/clickhouse/schema_definitions'
 require 'active_record/connection_adapters/clickhouse/schema_creation'
@@ -211,6 +212,9 @@ module ActiveRecord
           #register_class_with_limit m, %r(UInt128), Type::UnsignedInteger #not implemnted in clickhouse
           register_class_with_limit m, %r(UInt256), Type::UnsignedInteger
           # register_class_with_limit m, %r(Array), Clickhouse::OID::Array
+
+          m.register_type %r(uuid)i, Clickhouse::OID::Uuid.new
+
           m.register_type(%r(Array)) do |sql_type|
             Clickhouse::OID::Array.new(sql_type)
           end

--- a/spec/cases/model_spec.rb
+++ b/spec/cases/model_spec.rb
@@ -95,6 +95,27 @@ RSpec.describe 'Model', :migrations do
       end
     end
 
+    describe 'UUID column type' do
+      let(:random_uuid) { SecureRandom.uuid }
+      let!(:record1) do
+        model.create!(event_name: 'some event', event_value: 1, date: date, relation_uuid: random_uuid)
+      end
+
+      it 'is mapped to :uuid' do
+        type = model.columns_hash['relation_uuid'].type
+        expect(type).to eq(:uuid)
+      end
+
+      it 'accepts proper value' do
+        expect(record1.relation_uuid).to eq(random_uuid)
+      end
+
+      it 'does not accept invalid values' do
+        record1.relation_uuid = 'invalid-uuid'
+        expect(record1.relation_uuid).to be_nil
+      end
+    end
+
     describe '#settings' do
       it 'works' do
         sql = model.settings(optimize_read_in_order: 1, cast_keep_nullable: 1).to_sql


### PR DESCRIPTION
This PR backports UUID column support to the Rails 7.0 branch.