### PR TITLE
Use ILIKE for model.arel_table[:column]#matches

### DIFF
--- a/lib/arel/visitors/clickhouse.rb
+++ b/lib/arel/visitors/clickhouse.rb
@@ -53,6 +53,16 @@ module Arel
         collector
       end
 
+      def visit_Arel_Nodes_Matches(o, collector)
+        op = o.case_sensitive ? " LIKE " : " ILIKE "
+        infix_value o, collector, op
+      end
+
+      def visit_Arel_Nodes_DoesNotMatch(o, collector)
+        op = o.case_sensitive ? " NOT LIKE " : " NOT ILIKE "
+        infix_value o, collector, op
+      end
+
       def sanitize_as_setting_value(value)
         if value == :default
           'DEFAULT'

--- a/spec/cases/model_spec.rb
+++ b/spec/cases/model_spec.rb
@@ -143,6 +143,20 @@ RSpec.describe 'Model', :migrations do
       end
     end
 
+    describe 'arel predicates' do
+      describe '#matches' do
+        it 'uses ilike for case insensitive matches' do
+          sql = model.where(model.arel_table[:event_name].matches('some event')).to_sql
+          expect(sql).to eq("SELECT sample.* FROM sample WHERE sample.event_name ILIKE 'some event'")
+        end
+
+        it 'uses like for case sensitive matches' do
+          sql = model.where(model.arel_table[:event_name].matches('some event', nil, true)).to_sql
+          expect(sql).to eq("SELECT sample.* FROM sample WHERE sample.event_name LIKE 'some event'")
+        end
+      end
+    end
+
     describe 'DateTime64 create' do
       it 'create a new record' do
         time = DateTime.parse('2023-07-21 08:00:00.123')


### PR DESCRIPTION
I needed to dive into Arel for some queries, and I found that #matches was using LIKE instead of ILIKE. This PR is basically a copy/paste from Arel::Visitors::PostgreSQL:

https://github.com/rails/rails/blob/316338acf76c34b529e7d883a916ace798ad8efa/activerecord/lib/arel/visitors/postgresql.rb#L7-L27