### PR TITLE
Add support for binary string

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -207,12 +207,25 @@ module ActiveRecord
         end
 
         def format_body_response(body, format)
-          return body if body.blank? || format != DEFAULT_RESPONSE_FORMAT
+          return body if body.blank?
 
+          case format
+          when 'JSONCompact'
+            format_from_json_compact(body)
+          when 'JSONCompactEachRowWithNamesAndTypes'
+            format_from_json_compact_each_row_with_names_and_types(body)
+          else
+            body
+          end
+        end
+
+        def format_from_json_compact(body)
+          JSON.parse(body)
+        end
+
+        def format_from_json_compact_each_row_with_names_and_types(body)
           rows = body.split("\n").map { |row| JSON.parse(row) }
-          names = rows[0]
-          types = rows[1]
-          data = rows[2..]
+          names, types, *data = rows
 
           meta = names.zip(types).map do |name, type|
             {

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -6,6 +6,8 @@ module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
       module SchemaStatements
+        DEFAULT_RESPONSE_FORMAT = 'JSONCompactEachRowWithNamesAndTypes'.freeze
+
         def execute(sql, name = nil, settings: {})
           do_execute(sql, name, settings: settings)
         end
@@ -64,19 +66,19 @@ module ActiveRecord
 
         def do_system_execute(sql, name = nil)
           log_with_debug(sql, "#{adapter_name} #{name}") do
-            res = @connection.post("/?#{@connection_config.to_param}", "#{sql} FORMAT JSONCompact", 'User-Agent' => "Clickhouse ActiveRecord #{ClickhouseActiverecord::VERSION}")
+            res = @connection.post("/?#{@connection_config.to_param}", "#{sql} FORMAT #{DEFAULT_RESPONSE_FORMAT}", 'User-Agent' => "Clickhouse ActiveRecord #{ClickhouseActiverecord::VERSION}")
 
-            process_response(res)
+            process_response(res, DEFAULT_RESPONSE_FORMAT)
           end
         end
 
-        def do_execute(sql, name = nil, format: 'JSONCompact', settings: {})
+        def do_execute(sql, name = nil, format: DEFAULT_RESPONSE_FORMAT, settings: {})
           log(sql, "#{adapter_name} #{name}") do
             formatted_sql = apply_format(sql, format)
             request_params = @connection_config || {}
             res = @connection.post("/?#{request_params.merge(settings).to_param}", formatted_sql, 'User-Agent' => "Clickhouse ActiveRecord #{ClickhouseActiverecord::VERSION}")
 
-            process_response(res)
+            process_response(res, format)
           end
         end
 
@@ -116,13 +118,13 @@ module ActiveRecord
           format ? "#{sql} FORMAT #{format}" : sql
         end
 
-        def process_response(res)
+        def process_response(res, format)
           case res.code.to_i
           when 200
             if res.body.to_s.include?("DB::Exception")
               raise ActiveRecord::ActiveRecordError, "Response code: #{res.code}:\n#{res.body}"
             else
-              res.body.presence && JSON.parse(res.body)
+              format_body_response(res.body, format)
             end
           else
             case res.body
@@ -202,6 +204,27 @@ module ActiveRecord
 
         def has_default_function?(default_value, default) # :nodoc:
           !default_value && (%r{\w+\(.*\)} === default)
+        end
+
+        def format_body_response(body, format)
+          return body if body.blank? || format != DEFAULT_RESPONSE_FORMAT
+
+          rows = body.split("\n").map { |row| JSON.parse(row) }
+          names = rows[0]
+          types = rows[1]
+          data = rows[2..]
+
+          meta = names.zip(types).map do |name, type|
+            {
+              'name' => name,
+              'type' => type
+            }
+          end
+
+          {
+            'meta' => meta,
+            'data' => data
+          }
         end
       end
     end

--- a/spec/cases/model_spec.rb
+++ b/spec/cases/model_spec.rb
@@ -98,6 +98,17 @@ RSpec.describe 'Model', :migrations do
       end
     end
 
+    describe 'string column type as byte array' do
+      let(:bytes) { (0..255).to_a }
+      let!(:record1) { model.create!(event_name: 'some event', byte_array: bytes.pack('C*')) }
+
+      it 'keeps all bytes' do
+        returned_byte_array = model.first.byte_array
+
+        expect(returned_byte_array.unpack('C*')).to eq(bytes)
+      end
+    end
+
     describe 'UUID column type' do
       let(:random_uuid) { SecureRandom.uuid }
       let!(:record1) do

--- a/spec/cases/model_spec.rb
+++ b/spec/cases/model_spec.rb
@@ -22,12 +22,29 @@ RSpec.describe 'Model', :migrations do
       quietly { ActiveRecord::MigrationContext.new(migrations_dir, model.connection.schema_migration).up }
     end
 
-    it '#do_execute' do
-      result = model.connection.do_execute('SELECT 1 AS t', format: 'JSONCompact')
-      expect(result['data']).to eq([[1]])
-      expect(result['meta']).to eq([{'name' => 't', 'type' => 'UInt8'}])
-    end
+    describe '#do_execute' do
+      it 'returns formatted result' do
+        result = model.connection.do_execute('SELECT 1 AS t')
+        expect(result['data']).to eq([[1]])
+        expect(result['meta']).to eq([{ 'name' => 't', 'type' => 'UInt8' }])
+      end
 
+      context 'with JSONCompact format' do
+        it 'returns formatted result' do
+          result = model.connection.do_execute('SELECT 1 AS t', format: 'JSONCompact')
+          expect(result['data']).to eq([[1]])
+          expect(result['meta']).to eq([{ 'name' => 't', 'type' => 'UInt8' }])
+        end
+      end
+
+      context 'with JSONCompactEachRowWithNamesAndTypes format' do
+        it 'returns formatted result' do
+          result = model.connection.do_execute('SELECT 1 AS t', format: 'JSONCompactEachRowWithNamesAndTypes')
+          expect(result['data']).to eq([[1]])
+          expect(result['meta']).to eq([{ 'name' => 't', 'type' => 'UInt8' }])
+        end
+      end
+    end
 
     describe '#create' do
       it 'creates a new record' do

--- a/spec/fixtures/migrations/add_sample_data/1_create_sample_table.rb
+++ b/spec/fixtures/migrations/add_sample_data/1_create_sample_table.rb
@@ -9,6 +9,7 @@ class CreateSampleTable < ActiveRecord::Migration[5.0]
       t.date :date, null: false
       t.datetime :datetime, null: false
       t.datetime :datetime64, precision: 3, null: true
+      t.string :byte_array, null: true
       t.uuid :relation_uuid
     end
   end


### PR DESCRIPTION
This PR aims to add support for binary string. The main problem is that the 'JSONCompact' format removes invalid UTF-8 bytes. To fix this I needed to change the format to some 'EachRow' version. I chose 'JSONCompactEachRowWithNamesAndTypes'.

Any suggestions are welcome.

Documentation Sugestion: "Use the `JSONEachRow` format if you are sure that the data in the table can be formatted as JSON without losing any information."

Reference: https://clickhouse.com/docs/en/interfaces/formats#json-selecting-data
Issues: https://github.com/PNixx/clickhouse-activerecord/issues/57