### PR TITLE
Fix non-canonical UUID

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/oid/uuid.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/uuid.rb
@@ -6,6 +6,7 @@ module ActiveRecord
       module OID # :nodoc:
         class Uuid < Type::Value # :nodoc:
           ACCEPTABLE_UUID = %r{\A(\{)?([a-fA-F0-9]{4}-?){8}(?(1)\}|)\z}
+          CANONICAL_UUID = %r{\A[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\z}
 
           alias :serialize :deserialize
 
@@ -13,23 +14,32 @@ module ActiveRecord
             :uuid
           end
 
-          def changed?(old_value, new_value, _)
+          def changed?(old_value, new_value, _new_value_before_type_cast)
             old_value.class != new_value.class ||
-              new_value && old_value.casecmp(new_value) != 0
+              new_value != old_value
           end
 
           def changed_in_place?(raw_old_value, new_value)
             raw_old_value.class != new_value.class ||
-              new_value && raw_old_value.casecmp(new_value) != 0
+              new_value != raw_old_value
           end
 
           private
 
           def cast_value(value)
-            casted = value.to_s
-            casted if casted.match?(ACCEPTABLE_UUID)
+            value = value.to_s
+            format_uuid(value) if value.match?(ACCEPTABLE_UUID)
           end
-        end
+
+          def format_uuid(uuid)
+            if uuid.match?(CANONICAL_UUID)
+              uuid
+            else
+              uuid = uuid.delete("{}-").downcase
+              "#{uuid[..7]}-#{uuid[8..11]}-#{uuid[12..15]}-#{uuid[16..19]}-#{uuid[20..]}"
+            end
+          end
+        end        
       end
     end
   end

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -169,6 +169,11 @@ RSpec.describe 'Model', :migrations do
         expect(record1.relation_uuid).to eq(random_uuid)
       end
 
+      it 'accepts non-canonical uuid' do
+        record1.relation_uuid = 'ABCD-0123-4567-89EF-dead-beef-0101-1010'
+        expect(record1.relation_uuid).to eq('abcd0123-4567-89ef-dead-beef01011010')
+      end
+
       it 'does not accept invalid values' do
         record1.relation_uuid = 'invalid-uuid'
         expect(record1.relation_uuid).to be_nil


### PR DESCRIPTION
This PR aims to fix non-canonical UUID. The Clickhouse accepts only [8-4-4-4-12 representation of uuid]( https://clickhouse.com/docs/en/sql-reference/data-types/uuid).

Before (`master` branch):

```ruby
irb(main):001:0> Model.where(id: 'invalid')
D, [2024-03-23T21:47:16.862694 #29099] DEBUG -- :   Clickhouse Model Load (2.6ms)  SELECT models.* FROM models WHERE models.id = NULL /* loading for pp */ LIMIT 11
=> []                                                                                          
irb(main):002:0> Model.where(id: 'abcd0123456789efdeadbeef01011010')
D, [2024-03-23T21:47:23.081674 #29099] DEBUG -- :   Clickhouse Model Load (3.4ms)  SELECT models.* FROM models WHERE models.id = 'abcd0123456789efdeadbeef01011010' /* loading for pp */ LIMIT 11
=> [#<Model:0x00007fab2ac94140 id: "abcd0123-4567-89ef-dead-beef01011010", byte_string: "">]   
irb(main):003:0> Model.where(id: 'abcd-0123-4567-89ef-dead-beef-0101-1010').first
D, [2024-03-23T21:47:31.434351 #29099] DEBUG -- :   Clickhouse Model Load (2.8ms)  SELECT models.* FROM models WHERE models.id = 'abcd-0123-4567-89ef-dead-beef-0101-1010' ORDER BY models.id ASC LIMIT 1
/home/paulo/ProjetosGithub/clickhouse-activerecord/lib/active_record/connection_adapters/clickhouse/schema_statements.rb:150:in `process_response': Response code: 400: (ActiveRecord::ActiveRecordError)
Code: 53. DB::Exception: Cannot convert string abcd-0123-4567-89ef-dead-beef-0101-1010 to type UUID: while executing 'FUNCTION equals(id : 0, 'abcd-0123-4567-89ef-dead-beef-0101-1010' : 2) -> equals(id, 'abcd-0123-4567-89ef-dead-beef-0101-1010') UInt8 : 3'. (TYPE_MISMATCH) (version 22.8.21.38 (official build))    
```

After (`fix-non-canonical-uuid` branch):
```ruby
irb(main):001:0> Model.where(id: 'invalid')
D, [2024-03-23T21:42:32.408068 #27018] DEBUG -- :   Clickhouse Model Load (2.6ms)  SELECT models.* FROM models WHERE models.id = NULL /* loading for pp */ LIMIT 11
=> []                                                      
irb(main):002:0> Model.where(id: 'abcd0123456789efdeadbeef01011010')
D, [2024-03-23T21:43:02.179635 #27018] DEBUG -- :   Clickhouse Model Load (3.4ms)  SELECT models.* FROM models WHERE models.id = 'abcd0123-4567-89ef-dead-beef01011010' /* loading for pp */ LIMIT 11
=> [#<Model:0x00007f64c54bfc40 id: "abcd0123-4567-89ef-dead-beef01011010", byte_string: "">]
irb(main):003:0> Model.where(id: 'abcd-0123-4567-89ef-dead-beef-0101-1010').first
D, [2024-03-23T21:45:45.011951 #28468] DEBUG -- :   Clickhouse Model Load (4.0ms)  SELECT models.* FROM models WHERE models.id = 'abcd0123-4567-89ef-dead-beef01011010' ORDER BY models.id ASC LIMIT 1
=> #<Model:0x00007fdf93bd1fd0 id: "abcd0123-4567-89ef-dead-beef01011010", byte_string: "">                                                             
```


This implementation uses same idea of postgresql adapter: https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/postgresql/oid/uuid.rb