### PR TITLE
Don't throw exception when creating database

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -264,7 +264,7 @@ module ActiveRecord
 
       # Create a new ClickHouse database.
       def create_database(name)
-        sql = apply_cluster "CREATE DATABASE #{quote_table_name(name)}"
+        sql = apply_cluster "CREATE DATABASE IF NOT EXISTS #{quote_table_name(name)}"
         log_with_debug(sql, adapter_name) do
           res = @connection.post("/?#{@connection_config.except(:database).to_param}", sql)
           process_response(res)


### PR DESCRIPTION
This PR aims to fix exception when creating database. 

```
bundle exec rake db:create
Response code: 200:
clickhouse-5.my-cluster.cloud.b-pl.pro 9000 82 Code: 82. DB::Exception: Database my_database already exists. (DATABASE_ALREADY_EXISTS) (version 23.8.3.48 (official build)) 
Code: 82. DB::Exception: There was an error on [clickhouse-5.my-cluster.cloud.b-pl.pro:9000]: Code: 82. DB::Exception: Database my_database already exists. (DATABASE_ALREADY_EXISTS) (version 23.8.3.48 (official build)). (DATABASE_ALREADY_EXISTS) (version 23.8.3.48 (official build))
Couldn't create 'my_database' database. Please check your configuration.
rake aborted!
```

Clickhouse docs:
```
Clause IF NOT EXISTS
If the db_name database already exists, then ClickHouse does not create a new database and:

Doesn’t throw an exception if clause is specified.
Throws an exception if clause isn’t specified.
```

