### PR TITLE
Fix wrong method arguments

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -267,7 +267,7 @@ module ActiveRecord
         sql = apply_cluster "CREATE DATABASE #{quote_table_name(name)}"
         log_with_debug(sql, adapter_name) do
           res = @connection.post("/?#{@connection_config.except(:database).to_param}", sql)
-          process_response(res)
+          process_response(res, DEFAULT_RESPONSE_FORMAT)
         end
       end
 
@@ -312,7 +312,7 @@ module ActiveRecord
         sql = apply_cluster "DROP DATABASE IF EXISTS #{quote_table_name(name)}"
         log_with_debug(sql, adapter_name) do
           res = @connection.post("/?#{@connection_config.except(:database).to_param}", sql)
-          process_response(res)
+          process_response(res, DEFAULT_RESPONSE_FORMAT)
         end
       end
 


### PR DESCRIPTION
Following up on @PauloMiranda98 's PR here: https://github.com/PNixx/clickhouse-activerecord/pull/116

I think he missed two places to update `process_response`. After the PR the arity of process_response is 2

```ruby
       def process_response(res, format)
          case res.code.to_i
          when 200
          ...
       end
```

The symptom is that I am getting the following error when trying to drop or create a clickhouse db

```
bin/rails aborted!
ArgumentError: wrong number of arguments (given 1, expected 2) (ArgumentError)
REDACTED/clickhouse-activerecord/lib/active_record/connection_adapters/clickhouse/schema_statements.rb:121:in `process_response'
REDACTED/clickhouse-activerecord/lib/active_record/connection_adapters/clickhouse_adapter.rb:316:in `block in drop_database'
REDACTED/clickhouse-activerecord/lib/active_record/connection_adapters/clickhouse/schema_statements.rb:144:in `log_with_debug'
REDACTED/clickhouse-activerecord/lib/active_record/connection_adapters/clickhouse_adapter.rb:314:in `drop_database'
REDACTED/clickhouse-activerecord/lib/clickhouse-activerecord/tasks.rb:24:in `drop'
``