### PR TITLE
Fix precision loss due to JSON float parsing

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -233,11 +233,11 @@ module ActiveRecord
         end
 
         def format_from_json_compact(body)
-          JSON.parse(body)
+          parse_json_payload(body)
         end
 
         def format_from_json_compact_each_row_with_names_and_types(body)
-          rows = body.split("\n").map { |row| JSON.parse(row) }
+          rows = body.split("\n").map { |row| parse_json_payload(row) }
           names, types, *data = rows
 
           meta = names.zip(types).map do |name, type|
@@ -251,6 +251,10 @@ module ActiveRecord
             'meta' => meta,
             'data' => data
           }
+        end
+
+        def parse_json_payload(payload)
+          JSON.parse(payload, decimal_class: BigDecimal)
         end
       end
     end

--- a/spec/fixtures/migrations/add_sample_data/1_create_sample_table.rb
+++ b/spec/fixtures/migrations/add_sample_data/1_create_sample_table.rb
@@ -11,6 +11,7 @@ class CreateSampleTable < ActiveRecord::Migration[5.0]
       t.datetime :datetime64, precision: 3, null: true
       t.string :byte_array, null: true
       t.uuid :relation_uuid
+      t.decimal :decimal_value, precision: 38, scale: 16, null: true
     end
   end
 end

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -180,6 +180,19 @@ RSpec.describe 'Model', :migrations do
       end
     end
 
+    describe 'decimal column type' do
+      let!(:record1) do
+        Model.create!(event_name: 'some event', decimal_value: BigDecimal('95891.74'))
+      end
+
+      # If converted to float, the value would be 9589174.000000001. This happened previously
+      # due to JSON parsing of numeric values to floats.
+      it 'keeps precision' do
+        decimal_value = Model.first.decimal_value
+        expect(decimal_value).to eq(BigDecimal('95891.74'))
+      end
+    end
+
     describe '#settings' do
       it 'works' do
         sql = Model.settings(optimize_read_in_order: 1, cast_keep_nullable: 1).to_sql


### PR DESCRIPTION
## Intro

I noticed a strange bug, where `95891.74` was converted to `9589174.000000001`. After investigation in turned out that the value was correctly stored in clickhouse, the data type was also correct. However it seemed that down the line it was converted to a float somewhere. It turned out it was the JSON parsing that converts numeric values to Floats. 

```ruby
decimal = ActiveModel::Type::Decimal.new(precision: 38, scale: 16, limit: nil)
decimal.cast(JSON.parse("95891.74"))
# => 0.9589174000000001e5

decimal.cast(JSON.parse("95891.74", decimal_class: BigDecimal))
# => 0.9589174e5
```

So, telling JSON to convert all numerics to BigDecimal helps with further precision handling.