### PR TITLE
Quote table names with periods when dumping schemas

### DIFF
--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -104,7 +104,8 @@ HEADER
               raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
               next if column.name == pk
               type, colspec = column_spec(column)
-              tbl.print "    t.#{type} #{column.name.inspect}"
+              name = column.name =~ (/\./) ? "\"`#{column.name}`\"" : column.name.inspect
+              tbl.print "    t.#{type} #{name}"
               tbl.print ", #{format_colspec(colspec)}" if colspec.present?
               tbl.puts
             end


### PR DESCRIPTION
In Clickhouse, table names with periods are legal. The name must be quoted with backticks, however. This PR fixes the schema dumper to automatically quote column names with a period in them with backticks.

For column names with periods, this makes the schema restore for tests work correctly.  For columns without periods, the change will have no effect. 