### PR TITLE
Add support for `CREATE FUNCTION` and `CREATE OR REPLACE FUNCTION`; the later in schema loading

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -351,8 +351,8 @@ module ActiveRecord
         end
       end
 
-      def create_function(name, body)
-        fd = "CREATE OR REPLACE FUNCTION #{apply_cluster(quote_table_name(name))} AS #{body}"
+      def create_function(name, body, force: false)
+        fd = "CREATE#{' OR REPLACE' if force} FUNCTION #{apply_cluster(quote_table_name(name))} AS #{body}"
         do_execute(fd, format: nil)
       end
 

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -351,8 +351,8 @@ module ActiveRecord
         end
       end
 
-      def create_function(name, body, force: false)
-        fd = "CREATE#{' OR REPLACE' if force} FUNCTION #{apply_cluster(quote_table_name(name))} AS #{body}"
+      def create_function(name, body, **options)
+        fd = "CREATE#{' OR REPLACE' if options[:force]} FUNCTION #{apply_cluster(quote_table_name(name))} AS #{body}"
         do_execute(fd, format: nil)
       end
 

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -352,7 +352,7 @@ module ActiveRecord
       end
 
       def create_function(name, body)
-        fd = "CREATE FUNCTION #{apply_cluster(quote_table_name(name))} AS #{body}"
+        fd = "CREATE OR REPLACE FUNCTION #{apply_cluster(quote_table_name(name))} AS #{body}"
         do_execute(fd, format: nil)
       end
 

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -112,7 +112,7 @@ module ClickhouseActiverecord
       stream.puts "  # FUNCTION: #{function}"
       sql = @connection.show_create_function(function)
       stream.puts "  # SQL: #{sql}" if sql
-      stream.puts "  create_function \"#{function}\", \"#{sql.gsub(/^CREATE FUNCTION (.*?) AS/, '').strip}\"" if sql
+      stream.puts "  create_function \"#{function}\", \"#{sql.gsub(/^CREATE FUNCTION (.*?) AS/, '').strip}\", force: true" if sql
     end
 
     def format_options(options)

--- a/spec/cluster/migration_spec.rb
+++ b/spec/cluster/migration_spec.rb
@@ -70,9 +70,12 @@ RSpec.describe 'Cluster Migration', :migrations do
           let(:directory) { 'dsl_create_function' }
 
           it 'creates a function' do
+            ActiveRecord::Base.connection.do_execute('CREATE FUNCTION forced_fun AS (x, k, b) -> k*x + b', format: nil)
+
             subject
 
-            expect(ActiveRecord::Base.connection.functions).to match_array(['some_fun'])
+            expect(ActiveRecord::Base.connection.functions).to match_array(['some_fun', 'forced_fun'])
+            expect(ActiveRecord::Base.connection.show_create_function('forced_fun').chomp).to eq('CREATE FUNCTION forced_fun AS (x, y) -> (x + y)')
           end
         end
       end

--- a/spec/fixtures/migrations/dsl_create_function/1_create_some_function.rb
+++ b/spec/fixtures/migrations/dsl_create_function/1_create_some_function.rb
@@ -3,5 +3,6 @@
 class CreateSomeFunction < ActiveRecord::Migration[7.1]
   def up
     create_function :some_fun, "(x,y) -> x + y"
+    create_function :forced_fun, "(x,y) -> x + y", force: true
   end
 end

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -369,9 +369,12 @@ RSpec.describe 'Migration', :migrations do
       context 'dsl' do
         let(:directory) { 'dsl_create_function' }
         it 'creates a function' do
+          ActiveRecord::Base.connection.do_execute('CREATE FUNCTION forced_fun AS (x, k, b) -> k*x + b', format: nil)
+
           subject
 
-          expect(ActiveRecord::Base.connection.functions).to match_array(['some_fun'])
+          expect(ActiveRecord::Base.connection.functions).to match_array(['some_fun', 'forced_fun'])
+          expect(ActiveRecord::Base.connection.show_create_function('forced_fun').chomp).to eq('CREATE FUNCTION forced_fun AS (x, y) -> (x + y)')
         end
       end
     end


### PR DESCRIPTION
Fixes ##145

In a rails app, with existing Clickhouse schema w/a function defined, a `rails db:schema:load` will not always succeed; this is because the function may already exist.

```
Code: 609. DB::Exception: User-defined function 'uuid7ToDateTime' already exists. (FUNCTION_ALREADY_EXISTS) (version 23.9.6.20 (official build))
```

This can be addressed in at least two ways:
1. Guard the `CREATE FUNCTION` statement with `IF NOT EXISTS`; this would prevent trying to create the function, however, it also does not guarantee that the function is up-to-date with the schema
2. Use `CREATE OR REPLACE FUNCTION` instead. This has the benefit of ensuring the function is up-to-date with the schema

This commit pursues option #2. It adds a `force` option to the `create_function` method definition; `force: true` us used when dumping the schema so that schema can be dumped/loaded idempotently.