### PR TITLE
Normalize table name in schema dump

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -264,7 +264,7 @@ module ActiveRecord
       # @param [String] table
       # @return [String]
       def show_create_table(table)
-        do_system_execute("SHOW CREATE TABLE `#{table}`")['data'].try(:first).try(:first).gsub(/[\n\s]+/m, ' ').gsub("#{ActiveRecord::Base.connection_db_config.database}.", "")
+        do_system_execute("SHOW CREATE TABLE `#{table}`")['data'].try(:first).try(:first).gsub(/[\n\s]+/m, ' ').gsub("#{@config[:database]}.", "")
       end
 
       # Create a new ClickHouse database.

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -264,7 +264,7 @@ module ActiveRecord
       # @param [String] table
       # @return [String]
       def show_create_table(table)
-        do_system_execute("SHOW CREATE TABLE `#{table}`")['data'].try(:first).try(:first).gsub(/[\n\s]+/m, ' ')
+        do_system_execute("SHOW CREATE TABLE `#{table}`")['data'].try(:first).try(:first).gsub(/[\n\s]+/m, ' ').gsub("#{ActiveRecord::Base.connection_db_config.database}.", "")
       end
 
       # Create a new ClickHouse database.


### PR DESCRIPTION
When running separate databases for different environments (i.e. development, test) on the same machine, you will likely specify a different database name in `database.yml`. If you then run migrations in a different ENV, you will get schema changes as the database name will be dumped to the schema comments.

This change strips the database name from the schema, leaving only the table name.

Before:
```ruby
# SQL: CREATE TABLE database_name.table_name
create_table "table_name" ...
```

Afteer:
```ruby
# SQL: CREATE TABLE table_name
create_table "table_name" ...
```