### PR TITLE
Noop savepoint functionality

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -133,6 +133,16 @@ module ActiveRecord
         connect
       end
 
+      # Savepoints are not supported, noop
+      def create_savepoint(name)
+      end
+
+      def exec_rollback_to_savepoint(name)
+      end
+
+      def release_savepoint(name)
+      end
+
       def migrations_paths
         @config[:migrations_paths] || 'db/migrate_clickhouse'
       end


### PR DESCRIPTION
Fixes error described in #107; since clickhouse does not support transactions or savepoints, these methods should noop instead of raise a `NotImplementedError` which can originate from [this call site](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L418).