### PR TITLE
Fix change_column functionality

### DIFF
--- a/spec/fixtures/migrations/dsl_change_column/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_change_column/1_create_some_table.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateSomeTable < ActiveRecord::Migration[7.1]
+  def up
+    create_table :some, options: 'MergeTree ORDER BY id' do |t|
+      t.integer :col, limit: 4, null: false
+    end
+  end
+end
+

--- a/spec/fixtures/migrations/dsl_change_column/2_alter_col_column.rb
+++ b/spec/fixtures/migrations/dsl_change_column/2_alter_col_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AlterColColumn < ActiveRecord::Migration[7.1]
+  def up
+    change_column :some, :col, :int64, null: false
+  end
+end

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -340,6 +340,21 @@ RSpec.describe 'Migration', :migrations do
       end
     end
 
+    describe 'alter column' do
+      let(:directory) { 'dsl_change_column' }
+      it 'alters the column' do
+        subject
+
+        current_schema = schema(model)
+
+        expect(current_schema.keys.count).to eq(2)
+        expect(current_schema).to have_key('id')
+        expect(current_schema).to have_key('col')
+        expect(current_schema['id'].sql_type).to eq('UInt32')
+        expect(current_schema['col'].sql_type).to eq('Int64')
+      end
+    end
+
     context 'function creation' do
       after do
         ActiveRecord::Base.connection.drop_functions

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,8 +39,8 @@ ActiveRecord::Base.configurations = HashWithIndifferentAccess.new(
     host: 'localhost',
     port: ENV['CLICKHOUSE_PORT'] || 8123,
     database: ENV['CLICKHOUSE_DATABASE'] || 'test',
-    username: nil,
-    password: nil,
+    username: 'default',
+    password: 'docker',
     use_metadata_table: false,
     cluster_name: ENV['CLICKHOUSE_CLUSTER'],
   }


### PR DESCRIPTION
When calling the underlying ActiveRecord methods, there was an issue with the arguments not matching. This PR fixes the issue and includes additional specs to ensure this works and doesn't regress.