### PR TITLE
Fix `#find_by`

### DIFF
--- a/lib/arel/visitors/clickhouse.rb
+++ b/lib/arel/visitors/clickhouse.rb
@@ -16,8 +16,12 @@ module Arel
       # https://clickhouse.com/docs/en/sql-reference/statements/delete
       # DELETE and UPDATE in ClickHouse working only without table name
       def visit_Arel_Attributes_Attribute(o, collector)
-        collector << quote_table_name(o.relation.table_alias || o.relation.name) << '.' unless collector.value.start_with?('DELETE FROM ') || collector.value.include?(' UPDATE ')
-        collector << quote_column_name(o.name)
+        if collector.value.is_a?(String)
+          collector << quote_table_name(o.relation.table_alias || o.relation.name) << '.' unless collector.value.start_with?('DELETE FROM ') || collector.value.include?(' UPDATE ')
+          collector << quote_column_name(o.name)
+        else
+          super
+        end
       end
 
       def visit_Arel_Nodes_SelectOptions(o, collector)

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -107,6 +107,14 @@ RSpec.describe 'Model', :migrations do
       end
     end
 
+    describe '#find_by' do
+      let!(:record) { Model.create!(id: 1, event_name: 'some event') }
+
+      it 'finds the record' do
+        expect(Model.find_by(id: 1, event_name: 'some event')).to eq(record)
+      end
+    end
+
     describe '#reverse_order!' do
       it 'blank' do
         expect(Model.all.reverse_order!.map(&:event_name)).to eq([])


### PR DESCRIPTION
```ruby
  1) Model sample #find_by finds the record
     Failure/Error: collector << quote_table_name(o.relation.table_alias || o.relation.name) << '.' unless collector.value.start_with?('DELETE FROM ') || collector.value.include?(' UPDATE ')

     NoMethodError:
       undefined method `start_with?' for [["SELECT", " "], []]:Array
     # ./lib/arel/visitors/clickhouse.rb:19:in `visit_Arel_Attributes_Attribute'
     # ./spec/single/model_spec.rb:114:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:29:in `block (2 levels) in <top (required)>'
```