### PR TITLE
Add `group_by_grouping_sets` query method

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -2,6 +2,7 @@
 
 require 'arel/visitors/clickhouse'
 require 'arel/nodes/final'
+require 'arel/nodes/grouping_sets'
 require 'arel/nodes/settings'
 require 'arel/nodes/using'
 require 'active_record/connection_adapters/clickhouse/oid/array'
@@ -47,7 +48,11 @@ module ActiveRecord
 
   module ModelSchema
     module ClassMethods
-      delegate :final, :final!, :settings, :settings!, :window, :window!, to: :all
+      delegate :final, :final!,
+               :group_by_grouping_sets, :group_by_grouping_sets!,
+               :settings, :settings!,
+               :window, :window!,
+               to: :all
 
       def is_view
         @is_view || false

--- a/lib/arel/nodes/grouping_sets.rb
+++ b/lib/arel/nodes/grouping_sets.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  module Nodes
+    class GroupingSets < Arel::Nodes::Unary
+
+      def initialize(expr)
+        super
+        @expr = wrap_grouping_sets(expr)
+      end
+
+      private
+
+      def wrap_grouping_sets(sets)
+        sets.map do |element|
+          # See Arel::SelectManager#group
+          case element
+          when Array
+            wrap_grouping_sets(element)
+          when String
+            ::Arel::Nodes::SqlLiteral.new(element)
+          when Symbol
+            ::Arel::Nodes::SqlLiteral.new(element.to_s)
+          else
+            element
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/arel/visitors/clickhouse.rb
+++ b/lib/arel/visitors/clickhouse.rb
@@ -45,6 +45,11 @@ module Arel
         collector
       end
 
+      def visit_Arel_Nodes_GroupingSets(o, collector)
+        collector << 'GROUPING SETS '
+        grouping_array_or_grouping_element(o.expr, collector)
+      end
+
       def visit_Arel_Nodes_Settings(o, collector)
         return collector if o.expr.empty?
 
@@ -93,6 +98,25 @@ module Arel
       def sanitize_as_setting_name(value)
         return value if Arel::Nodes::SqlLiteral === value
         @connection.sanitize_as_setting_name(value)
+      end
+
+      private
+
+      # Utilized by GroupingSet, Cube & RollUp visitors to
+      # handle grouping aggregation semantics
+      def grouping_array_or_grouping_element(o, collector)
+        if o.is_a? Array
+          collector << '( '
+          o.each_with_index do |el, i|
+            collector << ', ' if i > 0
+            grouping_array_or_grouping_element el, collector
+          end
+          collector << ' )'
+        elsif o.respond_to? :expr
+          visit o.expr, collector
+        else
+          visit o, collector
+        end
       end
 
     end

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -293,6 +293,38 @@ RSpec.describe 'Model', :migrations do
         expect(Model.final.where(date: '2023-07-21').to_sql).to eq('SELECT sample.* FROM sample FINAL WHERE sample.date = \'2023-07-21\'')
       end
     end
+
+
+    describe '#group_by_grouping_sets' do
+      it 'raises an error with no arguments' do
+        expect { Model.group_by_grouping_sets }.to raise_error(ArgumentError, 'The method .group_by_grouping_sets() must contain arguments.')
+      end
+
+      it 'works with the empty grouping set' do
+        sql = Model.group_by_grouping_sets([]).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample GROUP BY GROUPING SETS ( (  ) )')
+      end
+
+      it 'accepts strings' do
+        sql = Model.group_by_grouping_sets(%w[foo bar], %w[baz]).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample GROUP BY GROUPING SETS ( ( foo, bar ), ( baz ) )')
+      end
+
+      it 'accepts symbols' do
+        sql = Model.group_by_grouping_sets(%i[foo bar], %i[baz]).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample GROUP BY GROUPING SETS ( ( foo, bar ), ( baz ) )')
+      end
+
+      it 'accepts Arel nodes' do
+        sql = Model.group_by_grouping_sets([Model.arel_table[:foo], Model.arel_table[:bar]], [Model.arel_table[:baz]]).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample GROUP BY GROUPING SETS ( ( sample.foo, sample.bar ), ( sample.baz ) )')
+      end
+
+      it 'accepts mixed arguments' do
+        sql = Model.group_by_grouping_sets(['foo', :bar], [Model.arel_table[:baz]]).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample GROUP BY GROUPING SETS ( ( foo, bar ), ( sample.baz ) )')
+      end
+    end
   end
 
   context 'sample with id column' do


### PR DESCRIPTION
Implements [`GROUP BY GROUPING SETS`](https://clickhouse.com/docs/en/sql-reference/aggregate-functions/grouping_function#grouping-sets). (Haven't done `CUBE` or `ROLLUP` yet.)

Example:
```ruby
users = User.group_by_grouping_sets([], [:name], [:name, :age]).select(:name, :age, 'count(*)')
```
generates:
```sql
SELECT name, age, count(*) FROM users GROUP BY GROUPING SETS ( (), (name), (name, age) )
```

Accepts arrays of strings, symbols, and Arel nodes, as well as any arbitrary mix of them.