### PR TITLE
Add blank line after create_function in schema

### DIFF
--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -111,8 +111,11 @@ module ClickhouseActiverecord
     def function(function, stream)
       stream.puts "  # FUNCTION: #{function}"
       sql = @connection.show_create_function(function)
-      stream.puts "  # SQL: #{sql}" if sql
-      stream.puts "  create_function \"#{function}\", \"#{sql.gsub(/^CREATE FUNCTION (.*?) AS/, '').strip}\", force: true" if sql
+      if sql
+        stream.puts "  # SQL: #{sql}"
+        stream.puts "  create_function \"#{function}\", \"#{sql.gsub(/^CREATE FUNCTION (.*?) AS/, '').strip}\", force: true"
+        stream puts
+      end
     end
 
     def format_options(options)

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -114,7 +114,7 @@ module ClickhouseActiverecord
       if sql
         stream.puts "  # SQL: #{sql}"
         stream.puts "  create_function \"#{function}\", \"#{sql.gsub(/^CREATE FUNCTION (.*?) AS/, '').strip}\", force: true"
-        stream puts
+        stream.puts
       end
     end
 


### PR DESCRIPTION
Before:
```sql
# FUNCTION: uuid7ToBeginningOfDay
  # SQL: CREATE FUNCTION uuid7ToBeginningOfDay AS input -> toUUID(concat(hex(reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))) - (reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))) % 86400000)), \'00000000000000000000\'))
  create_function "uuid7ToBeginningOfDay", "input -> toUUID(concat(hex(reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))) - (reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))) % 86400000)), \'00000000000000000000\'))", force: true
  # FUNCTION: uuid7ToDateTime
  # SQL: CREATE FUNCTION uuid7ToDateTime AS input -> fromUnixTimestamp64Milli(reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))))
  create_function "uuid7ToDateTime", "input -> fromUnixTimestamp64Milli(reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))))", force: true
  # FUNCTION: uuidToBeginningOfDayDateTime
  # SQL: CREATE FUNCTION uuidToBeginningOfDayDateTime AS input -> reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12))))
  create_function "uuidToBeginningOfDayDateTime", "input -> reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12))))", force: true
```

After:
```sql
# FUNCTION: fooBar
  # SQL: CREATE FUNCTION uuid7ToBeginningOfDay AS input -> toUUID(concat(hex(reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))) - (reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))) % 86400000)), \'00000000000000000000\'))
  create_function "uuid7ToBeginningOfDay", "input -> toUUID(concat(hex(reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))) - (reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))) % 86400000)), \'00000000000000000000\'))", force: true

  # FUNCTION: uuid7ToDateTime
  # SQL: CREATE FUNCTION uuid7ToDateTime AS input -> fromUnixTimestamp64Milli(reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))))
  create_function "uuid7ToDateTime", "input -> fromUnixTimestamp64Milli(reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12)))))", force: true

  # FUNCTION: uuidToBeginningOfDayDateTime
  # SQL: CREATE FUNCTION uuidToBeginningOfDayDateTime AS input -> reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12))))
  create_function "uuidToBeginningOfDayDateTime", "input -> reinterpretAsUInt64(reverse(unhex(substring(hex(input), 1, 12))))", force: true
```