### PR TITLE
Include column definitions in schema dump if the column name is not `id`

### DIFF
--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -78,7 +78,7 @@ module ClickhouseActiverecord
           if simple || !match
             columns.each do |column|
               raise StandardError, "Unknown type '#{column.sql_type}' for column '#{column.name}'" unless @connection.valid_type?(column.type)
-              next if column.name == pk
+              next if column.name == pk && column.name == "id"
               type, colspec = column_spec(column)
               name = column.name =~ (/\./) ? "\"`#{column.name}`\"" : column.name.inspect
               tbl.print "    t.#{type} #{name}"


### PR DESCRIPTION
Mitigates #171 by including primary key columns in the column definition if the primary key is not named `id`. This mirrors behavior prior to `ddfa259bbec88aefa3eaf2942392b8473a477601` while continuing to omit the primary key column if the name is `id`.

This is likely only a partial solution that seems like the best short-term path forward. A better long-term solution likely relies on #172 being solved such that passing `id: :TYPE_NOT_UInt32` is respected. This would also need to include non-integer data types such as `:datetime`.