### PR TITLE
Improve function dumps

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -73,7 +73,7 @@ module ActiveRecord
         end
 
         def functions
-          result = do_system_execute("SELECT name FROM system.functions WHERE origin = 'SQLUserDefined'")
+          result = do_system_execute("SELECT name FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name")
           return [] if result.nil?
           result['data'].flatten
         end

--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -52,7 +52,7 @@ module ClickhouseActiverecord
       # put to file
       File.open(args.first, 'w:utf-8') do |file|
         functions.each do |function|
-          file.puts function + ";\n\n"
+          file.puts function.gsub('\\n', "\n") + ";\n\n"
         end
 
         tables.each do |table|

--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -47,7 +47,7 @@ module ClickhouseActiverecord
       tables.sort_by! {|table| table.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) ? 1 : 0}
 
       # get all functions
-      functions = connection.execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined'")['data'].flatten
+      functions = connection.execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name")['data'].flatten
 
       # put to file
       File.open(args.first, 'w:utf-8') do |file|

--- a/spec/fixtures/migrations/plain_function_creation/1_create_some_function.rb
+++ b/spec/fixtures/migrations/plain_function_creation/1_create_some_function.rb
@@ -3,7 +3,12 @@
 class CreateSomeFunction < ActiveRecord::Migration[7.1]
   def up
     sql = <<~SQL
-      CREATE FUNCTION some_fun AS (x,y) -> x + y
+      CREATE FUNCTION multFun AS (x,y) -> x * y
+    SQL
+    do_execute(sql, format: nil)
+    
+    sql = <<~SQL
+      CREATE FUNCTION addFun AS (x,y) -> x + y
     SQL
     do_execute(sql, format: nil)
   end

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe 'Migration', :migrations do
         it 'creates a function' do
           subject
 
-          expect(ActiveRecord::Base.connection.functions).to match_array(['some_fun'])
+          expect(ActiveRecord::Base.connection.functions).to match_array(['addFun', 'multFun'])
         end
       end
 
@@ -392,7 +392,7 @@ RSpec.describe 'Migration', :migrations do
 
           subject
 
-          expect(ActiveRecord::Base.connection.functions).to match_array(['some_fun', 'forced_fun'])
+          expect(ActiveRecord::Base.connection.functions).to match_array(['forced_fun', 'some_fun'])
           expect(ActiveRecord::Base.connection.show_create_function('forced_fun').chomp).to eq('CREATE FUNCTION forced_fun AS (x, y) -> (x + y)')
         end
       end


### PR DESCRIPTION
This PR contains a couple small improvements to function dumps into structure.sql:
1. Preserve newlines, in case there are multi-line strings inside the function body
2. Sort functions by name so it's deterministic and behaves like tables