### PR TITLE
Reliably sort functions, views, and materialized views in schema

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -72,6 +72,12 @@ module ActiveRecord
           result['data'].flatten
         end
 
+        def materialized_views(name = nil)
+          result = do_system_execute("SHOW TABLES WHERE engine = 'MaterializedView'", name)
+          return [] if result.nil?
+          result['data'].flatten
+        end
+
         def functions
           result = do_system_execute("SELECT name FROM system.functions WHERE origin = 'SQLUserDefined'")
           return [] if result.nil?

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -15,13 +15,16 @@ module ClickhouseActiverecord
     private
 
     def tables(stream)
-      functions = @connection.functions
+      functions = @connection.functions.sort
       functions.each do |function|
         function(function, stream)
       end
 
-      sorted_tables = @connection.tables.sort {|a,b| @connection.show_create_table(a).match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) ? 1 : a <=> b }
-      sorted_tables.each do |table_name|
+      view_tables = @connection.views.sort
+      materialized_view_tables = @connection.materialized_views.sort
+      sorted_tables = @connection.tables.sort - view_tables - materialized_view_tables
+
+      (sorted_tables + view_tables + materialized_view_tables).each do |table_name|
         table(table_name, stream) unless ignored?(table_name)
       end
     end


### PR DESCRIPTION
Dependent on #180

+ sorts functions when dumping schema for consistent schema changes
+ reliably sorts views and materialized views in schema

Previously, functions where dumped in an unsorted fashion, resulting in changes to the schema when no actual changes where made.

Previously, views and materialized views were reliably placed after tables, however, a sorted order of those views was not enforced so the order of the views would change when no actual changes where made.