### PR TITLE
Fix Net::HTTP argument errors in the document

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class ActionView < ActiveRecord::Base
   establish_connection(
     adapter: 'clickhouse',
     database: 'database',
-    connection: Net::HTTP.start('http://example.org', 8123)
+    connection: Net::HTTP.start('example.org', 8123)
   )
 end
 ```


### PR DESCRIPTION
According to the [document](https://docs.ruby-lang.org/en/3.3/Net/HTTP.html?search=Net%3A%3AHTTP.start#method-c-start), the `Net::HTTP.start` parameter does not require `http://`.

Thanks