### PR TITLE
Maintain primary key type specificity

### DIFF
--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -109,6 +109,15 @@ module ClickhouseActiverecord
       end
     end
 
+    def column_spec_for_primary_key(column)
+      spec = super
+
+      id = ActiveRecord::ConnectionAdapters::ClickhouseAdapter::NATIVE_DATABASE_TYPES.invert[{name: column.sql_type.gsub(/\(\d+\)/, "")}]
+      spec[:id] = id.inspect if id.present?
+
+      spec.except!(:limit, :unsigned) # This can be removed at some date, it is only here to clean up existing schemas which have dumped these values already
+    end
+
     def function(function, stream)
       stream.puts "  # FUNCTION: #{function}"
       sql = @connection.show_create_function(function)


### PR DESCRIPTION
Partially fixes #172.

Previously schema would be dumped as such:

```ruby
create_table "my_table", id: :integer, limit: 2, unsigned: true do |t|
...
end
```

`limit` and `unsigned` would be ignored, resulting in an incorrect representation of the schema.

After it will specify the correct Clickhouse-native type:

```ruby
create_table "my_table", id: :uint8 do |t|
...
end
```

It does not address non-`id` named primary keys.