### PR TITLE
Restore multi-line table definitions in structure dumps

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -300,9 +300,11 @@ module ActiveRecord
       end
 
       # @param [String] table
+      # @option [Boolean] single_line
       # @return [String]
-      def show_create_table(table)
-        do_system_execute("SHOW CREATE TABLE `#{table}`")['data'].try(:first).try(:first).gsub(/[\n\s]+/m, ' ').gsub("#{@config[:database]}.", "")
+      def show_create_table(table, single_line: true)
+        sql = do_system_execute("SHOW CREATE TABLE `#{table}`")['data'].try(:first).try(:first)
+        single_line ? sql.squish : sql
       end
 
       # Create a new ClickHouse database.

--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -40,7 +40,7 @@ module ClickhouseActiverecord
       # get all tables
       tables = connection.execute("SHOW TABLES FROM #{@configuration.database} WHERE name NOT LIKE '.inner_id.%'")['data'].flatten.map do |table|
         next if %w[schema_migrations ar_internal_metadata].include?(table)
-        connection.show_create_table(table).gsub("#{@configuration.database}.", '')
+        connection.show_create_table(table, single_line: false).gsub("#{@configuration.database}.", '')
       end.compact
 
       # sort view to last


### PR DESCRIPTION
Refactoring commit (535ca30d) that altered :structure_dump to use :show_create_table made table definitions in structure.sql single-line. This restores line breaks in structure.sql.