### PR TITLE
Use a flag to track updates/deletes in SQL visitor

### DIFF
--- a/lib/arel/visitors/clickhouse.rb
+++ b/lib/arel/visitors/clickhouse.rb
@@ -4,6 +4,11 @@ module Arel
   module Visitors
     class Clickhouse < ::Arel::Visitors::ToSql
 
+      def compile(node, collector = Arel::Collectors::SQLString.new)
+        @delete_or_update = false
+        super
+      end
+
       def aggregate(name, o, collector)
         # replacing function name for materialized view
         if o.expressions.first && o.expressions.first != '*' && !o.expressions.first.is_a?(String) && o.expressions.first.relation&.is_view
@@ -16,12 +21,11 @@ module Arel
       # https://clickhouse.com/docs/en/sql-reference/statements/delete
       # DELETE and UPDATE in ClickHouse working only without table name
       def visit_Arel_Attributes_Attribute(o, collector)
-        if collector.value.is_a?(String)
-          collector << quote_table_name(o.relation.table_alias || o.relation.name) << '.' unless collector.value.start_with?('DELETE FROM ') || collector.value.include?(' UPDATE ')
-          collector << quote_column_name(o.name)
-        else
-          super
+        unless @delete_or_update
+          join_name  = o.relation.table_alias || o.relation.name
+          collector << quote_table_name(join_name) << '.'
         end
+        collector << quote_column_name(o.name)
       end
 
       def visit_Arel_Nodes_SelectOptions(o, collector)
@@ -30,6 +34,7 @@ module Arel
       end
 
       def visit_Arel_Nodes_UpdateStatement(o, collector)
+        @delete_or_update = true
         o = prepare_update_statement(o)
 
         collector << 'ALTER TABLE '
@@ -38,6 +43,11 @@ module Arel
         collect_nodes_for o.wheres, collector, ' WHERE ', ' AND '
         collect_nodes_for o.orders, collector, ' ORDER BY '
         maybe_visit o.limit, collector
+      end
+
+      def visit_Arel_Nodes_DeleteStatement(o, collector)
+        @delete_or_update = true
+        super
       end
 
       def visit_Arel_Nodes_Final(o, collector)
@@ -64,7 +74,7 @@ module Arel
         collector
       end
 
-      def visit_Arel_Nodes_Using o, collector
+      def visit_Arel_Nodes_Using(o, collector)
         collector << "USING "
         visit o.expr, collector
         collector


### PR DESCRIPTION
This was a small refactor we did to remove guesswork. Especially `collector.value.include?(' UPDATE ')` is prone to false positives, for example if you're working with an error column that logs query info, like `SELECT * FROM errors WHERE message ILIKE '%query failed: UPDATE table%'`. It also just felt weird to read from the collector to try to figure out what to do next.