### PR TITLE
`CREATE OR REPLACE FUNCTION` in SQL schema dumps

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -85,7 +85,7 @@ module ActiveRecord
         end
 
         def show_create_function(function)
-          do_execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined' AND name = '#{function}'", format: nil)
+          do_execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined' AND name = '#{function}'", format: nil).sub(/\ACREATE FUNCTION/, 'CREATE OR REPLACE FUNCTION')
         end
 
         def table_options(table)

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -126,7 +126,7 @@ module ClickhouseActiverecord
       sql = @connection.show_create_function(function)
       if sql
         stream.puts "  # SQL: #{sql}"
-        stream.puts "  create_function \"#{function}\", \"#{sql.gsub(/^CREATE FUNCTION (.*?) AS/, '').strip}\", force: true"
+        stream.puts "  create_function \"#{function}\", \"#{sql.sub(/\ACREATE(OR REPLACE)? FUNCTION .*? AS/, '').strip}\", force: true"
         stream.puts
       end
     end

--- a/spec/cluster/migration_spec.rb
+++ b/spec/cluster/migration_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Cluster Migration', :migrations do
             subject
 
             expect(ActiveRecord::Base.connection.functions).to match_array(['some_fun', 'forced_fun'])
-            expect(ActiveRecord::Base.connection.show_create_function('forced_fun').chomp).to eq('CREATE FUNCTION forced_fun AS (x, y) -> (x + y)')
+            expect(ActiveRecord::Base.connection.show_create_function('forced_fun').chomp).to eq('CREATE OR REPLACE FUNCTION forced_fun AS (x, y) -> (x + y)')
           end
         end
       end

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe 'Migration', :migrations do
           subject
 
           expect(ActiveRecord::Base.connection.functions).to match_array(['forced_fun', 'some_fun'])
-          expect(ActiveRecord::Base.connection.show_create_function('forced_fun').chomp).to eq('CREATE FUNCTION forced_fun AS (x, y) -> (x + y)')
+          expect(ActiveRecord::Base.connection.show_create_function('forced_fun').chomp).to eq('CREATE OR REPLACE FUNCTION forced_fun AS (x, y) -> (x + y)')
         end
       end
     end


### PR DESCRIPTION
Currently, Ruby schema dumps export functions with `force: true` to invoke `CREATE OR REPLACE FUNCTION`, but SQL schema dumps don't do the same. This leads to errors when reloading the schema (like in a test env), when schema loading should be idempotent.

This causes `show_create_function` to return SQL with `CREATE OR REPLACE FUNCTION` instead of just `CREATE FUNCTION`.