### PR TITLE
Add support for simple schema dumping

### DIFF
--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -31,6 +31,8 @@ module ClickhouseActiverecord
 
     def table(table, stream)
       if table.match(/^\.inner/).nil?
+        sql= ""
+        simple || = ENV['simple'] == 'true'
         unless simple
           stream.puts "  # TABLE: #{table}"
           sql = @connection.show_create_table(table)


### PR DESCRIPTION
While attempting to transition my codebase to use the simple schema dump option, I noticed a few things:

1) There is a small bug in the code that generates indexes for the sql comment. It relies on the sql variable, which is only defined if we are running a non-simple dump.
2) The simple flag works great for `rails db:schema:dump:clickhouse` but gets swallowed by `rails db:migrate:clickhouse`. I thought we could short-circuit that and inject directly. 