### PR TITLE
Unscope :final and :settings

### DIFF
--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -37,14 +37,26 @@ module CoreExtensions
       #   # SELECT users.* FROM users FINAL
       #
       # An <tt>ActiveRecord::ActiveRecordError</tt> will be raised if database not ClickHouse.
-      def final
-        spawn.final!
+      #
+      # @param [Boolean] final
+      def final(final = true)
+        spawn.final!(final)
       end
 
-      def final!
+      # @param [Boolean] final
+      def final!(final = true)
         check_command('FINAL')
-        @values[:final] = true
+        self.final_value = final
         self
+      end
+
+      def final_value=(value)
+        assert_mutability!
+        @values[:final] = value
+      end
+
+      def final_value
+        @values.fetch(:final, nil)
       end
 
       # GROUPING SETS allows you to specify multiple groupings in the GROUP BY clause.
@@ -139,7 +151,7 @@ module CoreExtensions
           arel = super(connection_or_aliases)
         end
 
-        arel.final! if @values[:final].present?
+        arel.final! if final_value
         arel.limit_by(*@values[:limit_by]) if @values[:limit_by].present?
         arel.settings(@values[:settings]) if @values[:settings].present?
         arel.using(@values[:using]) if @values[:using].present?

--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -25,7 +25,7 @@ module CoreExtensions
 
       # @param [Hash] opts
       def settings!(**opts)
-        check_command('SETTINGS')
+        check_command!('SETTINGS')
         @values[:settings] = (@values[:settings] || {}).merge opts
         self
       end
@@ -45,7 +45,7 @@ module CoreExtensions
 
       # @param [Boolean] final
       def final!(final = true)
-        check_command('FINAL')
+        check_command!('FINAL')
         self.final_value = final
         self
       end
@@ -140,7 +140,7 @@ module CoreExtensions
 
       private
 
-      def check_command(cmd)
+      def check_command!(cmd)
         raise ::ActiveRecord::ActiveRecordError, cmd + ' is a ClickHouse specific query clause' unless connection.is_a?(::ActiveRecord::ConnectionAdapters::ClickhouseAdapter)
       end
 

--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -1,6 +1,11 @@
 module CoreExtensions
   module ActiveRecord
     module Relation
+
+      def self.prepended(base)
+        base::VALID_UNSCOPING_VALUES << :final << :settings
+      end
+
       def reverse_order!
         return super unless connection.is_a?(::ActiveRecord::ConnectionAdapters::ClickhouseAdapter)
 

--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -49,7 +49,11 @@ module CoreExtensions
       end
 
       def settings_values=(value)
-        assert_mutability!
+        if ::ActiveRecord::version >= Gem::Version.new('7.2')
+          assert_modifiable!
+        else
+          assert_mutability!
+        end
         @values[:settings] = value
       end
 
@@ -74,7 +78,11 @@ module CoreExtensions
       end
 
       def final_value=(value)
-        assert_mutability!
+        if ::ActiveRecord::version >= Gem::Version.new('7.2')
+          assert_modifiable!
+        else
+          assert_mutability!
+        end
         @values[:final] = value
       end
 

--- a/lib/core_extensions/arel/nodes/select_core.rb
+++ b/lib/core_extensions/arel/nodes/select_core.rb
@@ -10,6 +10,13 @@ module CoreExtensions
           ::Arel::Nodes::Final.new(super)
         end
 
+        def hash
+          [
+            @source, @set_quantifier, @projections, @optimizer_hints,
+            @wheres, @groups, @havings, @windows, @comment, @final
+          ].hash
+        end
+
         def eql?(other)
           super && final == other.final
         end

--- a/lib/core_extensions/arel/nodes/select_statement.rb
+++ b/lib/core_extensions/arel/nodes/select_statement.rb
@@ -10,6 +10,10 @@ module CoreExtensions
           @settings = nil
         end
 
+        def hash
+          [@cores, @orders, @limit, @lock, @offset, @with, @settings].hash
+        end
+
         def eql?(other)
           super && 
             limit_by == other.limit_by &&

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -287,6 +287,18 @@ RSpec.describe 'Model', :migrations do
       end
     end
 
+    describe '#unscope' do
+      it 'removes settings' do
+        sql = Model.settings(foo: :bar).unscope(:settings).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample')
+      end
+
+      it 'removes FINAL' do
+        sql = Model.final.unscope(:final).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample')
+      end
+    end
+
     describe 'arel predicates' do
       describe '#matches' do
         it 'uses ilike for case insensitive matches' do

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -222,6 +222,31 @@ RSpec.describe 'Model', :migrations do
     end
 
     describe '#settings' do
+      it 'does not change settings_values when empty' do
+        query = Model.all
+        query = query.settings
+        expect(query.settings_values).to be_empty
+      end
+
+      it 'updates settings_values' do
+        query = Model.all
+        query = query.settings(foo: 'bar', abc: 123)
+        expect(query.settings_values).to eq({ foo: 'bar', abc: 123 })
+      end
+
+      it 'overwrites settings_values previously set' do
+        query = Model.all
+        query = query.settings(foo: 'bar', abc: 123)
+        query = query.settings(foo: 'baz')
+        expect(query.settings_values).to eq({ foo: 'baz', abc: 123 })
+      end
+
+      it 'works as a chainable method' do
+        query = Model.all
+        query = query.settings(foo: 'bar', abc: 123).settings(foo: 'baz')
+        expect(query.settings_values).to eq({ foo: 'baz', abc: 123 })
+      end
+
       it 'works' do
         sql = Model.settings(optimize_read_in_order: 1, cast_keep_nullable: 1).to_sql
         expect(sql).to eq('SELECT sample.* FROM sample SETTINGS optimize_read_in_order = 1, cast_keep_nullable = 1')


### PR DESCRIPTION
Changes the definition of `:final` and `:final!` to accept a boolean argument indicating whether to include the `FINAL` keyword. It is a code smell to have a boolean flag like this, but this keeps the API consistent with methods like `:lock`, `:readonly`, `:distinct`, etc.

This also refactors how `:final` and `:settings` are accessed in the Relation, again to be consistent with the `..._values` methods dynamically defined for other query methods. In addition to adding consistency, this also increases visibility into the Relation's state, making unit testing easier.

Lastly, this injects `:final` and `:settings` as unscopable values.