### PR TITLE
Fix FINAL to be emmited in the correct position

### DIFF
--- a/lib/arel/visitors/clickhouse.rb
+++ b/lib/arel/visitors/clickhouse.rb
@@ -50,9 +50,37 @@ module Arel
         super
       end
 
+      # def visit_Arel_Nodes_Final(o, collector)
+      #   # Handle FINAL clause placement correctly with JOINs
+      #   if o.expr.is_a?(Arel::Nodes::JoinSource)
+      #     # Visit the left side (main table) first
+      #     visit o.expr.left, collector
+      #     collector << ' FINAL'
+
+      #     # Then visit any RIGHT side (JOINs)
+      #     o.expr.right.each do |join|
+      #       collector << ' '
+      #       visit join, collector
+      #     end
+      #   else
+      #     # For simple cases without JOINs
+      #     visit o.expr, collector
+      #     collector << ' FINAL'
+      #   end
+      #   collector
+      # end
+
       def visit_Arel_Nodes_Final(o, collector)
-        visit o.expr, collector
+        # Visit the left side (main table) first
+        visit o.expr.left, collector
         collector << ' FINAL'
+
+        # Then visit any RIGHT side (JOINs)
+        o.expr.right.each do |join|
+          collector << ' '
+          visit join, collector
+        end
+
         collector
       end
 

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -418,6 +418,11 @@ RSpec.describe 'Model', :migrations do
         expect(Model.final!.count).to eq(1)
         expect(Model.final.where(date: '2023-07-21').to_sql).to eq('SELECT sample.* FROM sample FINAL WHERE sample.date = \'2023-07-21\'')
       end
+
+      it 'works with JOINs' do
+        sql = Model.final.joins(:joins).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample FINAL INNER JOIN joins ON joins.model_id = sample.event_name')
+      end
     end
 
     describe '#limit_by' do


### PR DESCRIPTION
Fixes #213 

The FINAL clause was being placed at the end of the query instead of right after the table name when JOINs or other composite expressions were present.

We fixed it in `lib/arel/visitors/clickhouse.rb#visit_Arel_Nodes_Final` by:
- Always visiting the left side of the expression first (this should always be the table name). 
- Add  FINAL right after the table name
- Then visit any other expressions that may exist on the right side of the node