### PR TITLE
Include schema_migrations in dump

### DIFF
--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -39,7 +39,8 @@ module ClickhouseActiverecord
 
       # get all tables
       tables = connection.execute("SHOW TABLES FROM #{@configuration.database} WHERE name NOT LIKE '.inner_id.%'")['data'].flatten.map do |table|
-        next if %w[schema_migrations ar_internal_metadata].include?(table)
+        next if %w[ar_internal_metadata].include?(table)
+
         connection.show_create_table(table, single_line: false).gsub("#{@configuration.database}.", '')
       end.compact
 


### PR DESCRIPTION
Without it, sql dumps don't actually get the table created (ever) and this is problematic in our CI pipelines.