### PR TITLE
Support truncating tables and importing fixtures (via execute_batch)

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -47,6 +47,12 @@ module ActiveRecord
           end
         end
 
+        def execute_batch(statements, name = nil, **kwargs)
+          statements.each do |statement|
+            execute(statement, name, **kwargs)
+          end
+        end
+
         def exec_insert(sql, name = nil, _binds = [], _pk = nil, _sequence_name = nil, returning: nil)
           new_sql = sql.sub(/ (DEFAULT )?VALUES/, " VALUES")
           with_response_format(nil) { execute(new_sql, name) }


### PR DESCRIPTION
Rails is using `execute_batch` when truncating tables and loading fixtures.

https://github.com/rails/rails/blob/bab99f8b51dfbff4d9e161b8f23c0dbf5d3b9314/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L232

https://github.com/rails/rails/blob/bab99f8b51dfbff4d9e161b8f23c0dbf5d3b9314/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L515

But since this gem is changing signature of `raw_execute`, then it does not work out of the box and needs to call `execute` instead.

https://github.com/rails/rails/blob/bab99f8b51dfbff4d9e161b8f23c0dbf5d3b9314/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L616-L620