### PR TITLE
fix: remove rake tasks loading in railtie

### DIFF
--- a/lib/clickhouse-activerecord/railtie.rb
+++ b/lib/clickhouse-activerecord/railtie.rb
@@ -9,7 +9,5 @@ module ClickhouseActiverecord
         ClickhouseActiverecord.load
       end
     end
-
-    rake_tasks { load 'tasks/clickhouse.rake' }
   end
 end


### PR DESCRIPTION
Fixes #218
Closes #125