### PR TITLE
Update the Quoting module to use backticks.

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/quoting.rb
+++ b/lib/active_record/connection_adapters/clickhouse/quoting.rb
@@ -4,13 +4,16 @@ module ActiveRecord
       module Quoting
         extend ActiveSupport::Concern
 
+        QUOTED_COLUMN_NAMES = Concurrent::Map.new
+        QUOTED_TABLE_NAMES = Concurrent::Map.new
+
         module ClassMethods # :nodoc:
           def quote_column_name(name)
-            name.to_s.include?('.') ? "`#{name}`" : name.to_s
+            QUOTED_COLUMN_NAMES[name] ||= "`#{name.to_s.gsub('`', '``')}`".freeze
           end
 
           def quote_table_name(name)
-            name.to_s
+            QUOTED_TABLE_NAMES[name] ||= "`#{name.to_s.gsub('`', '``').gsub('.', '`.`')}`".freeze
           end
         end
       end

--- a/spec/active_record/connection_adapters/clickhouse/quoting_spec.rb
+++ b/spec/active_record/connection_adapters/clickhouse/quoting_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ActiveRecord::ConnectionAdapters::Clickhouse::Quoting do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  describe '.quote_column_name' do
+    it 'quotes simple column names with backticks' do
+      [connection, connection.class].each do |adapter|
+        expect(adapter.quote_column_name('foo')).to eq('`foo`')
+      end
+    end
+
+    it 'escapes backticks in column names' do
+      [connection, connection.class].each do |adapter|
+        expect(adapter.quote_column_name('he`llo')).to eq('`he``llo`')
+      end
+    end
+
+    it 'handles double quotes in column names' do
+      [connection, connection.class].each do |adapter|
+        expect(adapter.quote_column_name('hel"lo')).to eq('`hel"lo`')
+      end
+    end
+  end
+
+  describe '.quote_table_name' do
+    it 'quotes simple table names with backticks' do
+      [connection, connection.class].each do |adapter|
+        expect(adapter.quote_table_name('foo')).to eq('`foo`')
+      end
+    end
+
+    it 'handles database.table syntax' do
+      [connection, connection.class].each do |adapter|
+        expect(adapter.quote_table_name('foo.bar')).to eq('`foo`.`bar`')
+      end
+    end
+
+    it 'escapes backticks in table names' do
+      [connection, connection.class].each do |adapter|
+        expect(adapter.quote_table_name('he`llo')).to eq('`he``llo`')
+      end
+    end
+
+    it 'handles complex names with dots and special characters' do
+      [connection, connection.class].each do |adapter|
+        expect(adapter.quote_table_name('hel"lo.wor\\ld')).to eq('`hel"lo`.`wor\\ld`')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What Changed

**This is potentially a breaking change**: We have a lot of failing tests that are directly comparing SQL strings but I did not see any actual application code test failures.

I updated `ActiveRecord::ConnectionAdapters::Clickhouse::Quoting` to add backticks to the quoted columns and tables. This pattern follows the Mysql approach and fixes an issue where a table name with say a hyphen (ex: `my-testing`) would not work.

I added new tests for the `ActiveRecord::ConnectionAdapters::Clickhouse::Quoting` class and updated the related tests to include the backticks.

## Testing the change

I have a table named `my-events`

```
) describe table `my-events`;

DESCRIBE TABLE `my-events`

Query id: 1e31e497-c79a-42be-a716-8dd92e07e45c

   ┌─name─┬─type───┬─default_type─┬─default_expression─┬─comment─┬─codec_expression─┬─ttl_expression─┐
1. │ id   │ UInt64 │              │                    │         │                  │                │
2. │ name │ String │              │                    │         │                  │                │
   └──────┴────────┴──────────────┴────────────────────┴─────────┴──────────────────┴────────────────┘

2 rows in set. Elapsed: 0.004 sec.
```

### Before the change

I am not able to query the table

```ruby
rails-clickhouse-testing(dev):002> MyEvent.all
  Clickhouse MyEvent Load (65.5ms)  SELECT my-events.* FROM my-events /* loading for pp */ LIMIT 11
An error occurred when inspecting the object: #<ActiveRecord::ActiveRecordError:"Response code: 400:\nCode: 62. DB::Exception: Syntax error: failed at position 27 (-): -events /* loading for pp */ LIMIT 11 FORMAT JSONCompactEachRowWithNamesAndTypes. Expected one of: token sequence, Dot, token, OpeningRoundBracket, UUID, alias, AS, identifier, FINAL, SAMPLE, table, table function, subquery or list of joined tables, array join, LEFT ARRAY JOIN, INNER, ARRAY JOIN, GLOBAL, LOCAL, ANY, ALL, ASOF, SEMI, ANTI, ONLY, LEFT, RIGHT, FULL, CROSS, PASTE, JOIN, PREWHERE, WHERE, GROUP BY, WITH, HAVING, WINDOW, QUALIFY, ORDER BY, LIMIT, OFFSET, FETCH, SETTINGS, UNION, EXCEPT, INTERSECT, INTO OUTFILE, FORMAT, ParallelWithClause, PARALLEL WITH, end of query. (SYNTAX_ERROR) (version 25.8.8.26 (official build))\n">
Result of Kernel#inspect: #<MyEvent::ActiveRecord_Relation:0x000000012adb24e8 @model=MyEvent (call 'MyEvent.load_schema' to load schema informations), @table=#<Arel::Table:0x000000012cf162d8 @name="my-events", @klass=MyEvent (call 'MyEvent.load_schema' to load schema informations), @type_caster=#<ActiveRecord::TypeCaster::Map:0x00000001299d0740 @klass=MyEvent (call 'MyEvent.load_schema' to load schema informations)>, @table_alias=nil>, @values={}, @loaded=false, @predicate_builder=#<ActiveRecord::PredicateBuilder:0x0000000129690d28 @table=#<ActiveRecord::TableMetadata:0x0000000129690ee0 @klass=MyEvent (call 'MyEvent.load_schema' to load schema informations), @arel_table=#<Arel::Table:0x000000012cf162d8 @name="my-events", @klass=MyEvent (call 'MyEvent.load_schema' to load schema informations), @type_caster=#<ActiveRecord::TypeCaster::Map:0x00000001299d0740 @klass=MyEvent (call 'MyEvent.load_schema' to load schema informations)>, @table_alias=nil>>, @handlers=[[Set, #<ActiveRecord::PredicateBuilder::ArrayHandler:0x000000012965f480 @predicate_builder=#<ActiveRecord::PredicateBuilder:0x0000000129690d28 ...>>], [Array, #<ActiveRecord::PredicateBuilder::ArrayHandler:0x0000000129690198 @predicate_builder=#<ActiveRecord::PredicateBuilder:0x0000000129690d28 ...>>], [ActiveRecord::Relation, #<ActiveRecord::PredicateBuilder::RelationHandler:0x0000000129690620>], [Range, #<ActiveRecord::PredicateBuilder::RangeHandler:0x0000000129690760 @predicate_builder=#<ActiveRecord::PredicateBuilder:0x0000000129690d28 ...>>], [BasicObject, #<ActiveRecord::PredicateBuilder::BasicObjectHandler:0x0000000129690ad0 @predicate_builder=#<ActiveRecord::PredicateBuilder:0x0000000129690d28 ...>>]]>, @delegate_to_model=false, @future_result=nil, @records=nil, @async=false, @none=false>                                                                                                                                   =>
```

### After the change

I am able to query the table

```ruby
rails-clickhouse-testing(dev):001> MyEvent.all
  Clickhouse MyEvent Load (16.2ms)  SELECT `my-events`.* FROM `my-events` /* loading for pp */ LIMIT 11
  Clickhouse my-events (system) (2.9ms)  DESCRIBE TABLE `my-events`
  Clickhouse (system) (5.8ms)  SHOW TABLES WHERE name NOT LIKE '.inner_id.%'
  Clickhouse (3.9ms)  SELECT version()
  Clickhouse (system) (15.8ms)  SHOW COLUMNS FROM `my-events`
=> [#<MyEvent:0x0000000123adfdd0 id: 1, name: "test">]
```

### Testing against production application

I ran these changes against the test suite of the production application I work on and everything passed except for tests where we were specifically testing against the SQL strings that were produced.

## Additional Info

I ended up on this path because I opened an issue last summer, https://github.com/PNixx/clickhouse-activerecord/issues/211, about parallel testing not working out of the box. Rails upstreamed a fix to create the parallel database names as `<name>_<N>` instead of `<name>-<N>` and that landed in Rails 8.1. When I created the issue I noted 

> It appears that ClickHouse does not support database names with hyphens in them, although I can't quite find any documentation on this.

The reason I couldn't find any documentation on that is because that statement isn't true. It's not about hyphens, its about special characters and quoting. 

```
) create database test-db;

Syntax error: failed at position 21 (-):

create database test-db;

Expected one of: UUID, ON, storage definition, ENGINE, PARTITION BY, PRIMARY KEY, ORDER BY, SAMPLE BY, TTL, COMMENT, table overrides declaration list, table override declaration, TABLE OVERRIDE, INTO OUTFILE, FORMAT, SETTINGS, ParallelWithClause, PARALLEL WITH, end of query
```

This doesn't work because ClickHouse interprets the hyphen as a subtraction, not as a string hyphen.

```
) create database `test-db`;

CREATE DATABASE `test-db`

Query id: 8d74daac-fea3-4d96-bb5a-abf2d3b99d48

Ok.

0 rows in set. Elapsed: 0.012 sec.
```

Quoting the database name works. Since `create_database` uses `quote_table_name`

```ruby
      # Create a new ClickHouse database.
      def create_database(name)
        sql = apply_cluster "CREATE DATABASE #{quote_table_name(name)}"
        do_system_execute sql, adapter_name, except_params: [:database]
      end
```

this patch backfills the solution to get the parallel tests working out of the box for Rails applications that are not on Rails 8.1.

## Rails Links

Here are some links to Rails code that I referenced when updating the tests to ensure the quoting approaches were the same.

MySQL Quoting Module: [activerecord/lib/active_record/connection_adapters/mysql/quoting.rb](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/mysql/quoting.rb)

Arel column handling (explains symbol vs string quoting behavior): [activerecord/lib/active_record/relation/query_methods.rb] (https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/query_methods.rb)
  - Lines 1662-1675: arel_columns method
  - Lines 1986-2005: arel_column method - shows how symbols get quoted via quote_table_name (line 2001) while strings become raw SQL literals (line 2003)

Arel GROUP BY tests (shows expected quoting behavior): [activerecord/test/cases/arel/select_manager_test.rb](https://github.com/rails/rails/blob/main/activerecord/test/cases/arel/select_manager_test.rb)
  - Lines 38-44: Symbol passed to group → unquoted (treated as SQL literal)
  - Lines 692-699: Arel attribute → quoted with table prefix
  - Lines 718-725: String passed to group → unquoted (treated as SQL literal)
