### PR TITLE
SchemaStatements#truncate_tables skips engines that cannot be truncated

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,18 @@ Structure load from `db/clickhouse_structure.sql` file:
 
 For auto truncate tables before each test add to `spec/rails_helper.rb` file:
 
-```
+```ruby
 require 'clickhouse-activerecord/rspec'
 ```
-    
+
+### Minitest
+
+For auto truncate tables before each test add to `test/test_helper.rb` file:
+
+```ruby
+require 'clickhouse-activerecord/minitest'
+```
+
 ### Insert and select data
 
 ```ruby

--- a/lib/clickhouse-activerecord/minitest.rb
+++ b/lib/clickhouse-activerecord/minitest.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ClickhouseActiverecord
+  module TestHelper
+    def before_setup
+      super
+      ActiveRecord::Base.configurations.configurations.select { |x| x.env_name == Rails.env && x.adapter == 'clickhouse' }.each do |config|
+        ActiveRecord::Base.establish_connection(config)
+        ActiveRecord::Base.connection.truncate_tables(*ActiveRecord::Base.connection.tables)
+      end
+    end
+  end
+end
+
+ActiveSupport::TestCase.include(ClickhouseActiverecord::TestHelper) if defined?(ActiveSupport::TestCase)

--- a/lib/clickhouse-activerecord/rspec.rb
+++ b/lib/clickhouse-activerecord/rspec.rb
@@ -4,9 +4,7 @@ RSpec.configure do |config|
   config.before do
     ActiveRecord::Base.configurations.configurations.select { |x| x.env_name == Rails.env && x.adapter == 'clickhouse' }.each do |config|
       ActiveRecord::Base.establish_connection(config)
-      ActiveRecord::Base.connection.tables.each do |table|
-        ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table}")
-      end
+      ActiveRecord::Base.connection.truncate_tables(*ActiveRecord::Base.connection.tables)
     end
   end
 end

--- a/spec/active_record/connection_adapters/clickhouse/schema_statements_spec.rb
+++ b/spec/active_record/connection_adapters/clickhouse/schema_statements_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe 'ActiveRecord::ConnectionAdapters::Clickhouse::SchemaStatements' do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  describe '#truncate_tables' do
+    before do
+      connection.execute('CREATE TABLE truncate_test (id UInt64, name String) ENGINE = MergeTree ORDER BY id')
+    end
+
+    after do
+      connection.execute('DROP DICTIONARY IF EXISTS truncate_test_dict')
+      connection.execute('DROP TABLE IF EXISTS truncate_test')
+      connection.execute('DROP TABLE IF EXISTS truncate_test2')
+      connection.execute('DROP VIEW IF EXISTS truncate_test_view')
+    end
+
+    it 'truncates multiple tables' do
+      connection.execute('CREATE TABLE truncate_test2 (id UInt64, value Int32) ENGINE = MergeTree ORDER BY id')
+      connection.exec_insert("INSERT INTO truncate_test (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+      connection.exec_insert("INSERT INTO truncate_test2 (id, value) VALUES (1, 100), (2, 200)")
+
+      expect(connection.select_value('SELECT count() FROM truncate_test')).to eq(2)
+      expect(connection.select_value('SELECT count() FROM truncate_test2')).to eq(2)
+
+      connection.truncate_tables('truncate_test', 'truncate_test2')
+
+      expect(connection.select_value('SELECT count() FROM truncate_test')).to eq(0)
+      expect(connection.select_value('SELECT count() FROM truncate_test2')).to eq(0)
+    end
+
+    it 'skips tables with unsupported engines' do
+      connection.execute('CREATE VIEW truncate_test_view AS SELECT * FROM truncate_test')
+      connection.execute(<<~SQL)
+        CREATE DICTIONARY truncate_test_dict (
+          id UInt64,
+          name String
+        )
+        PRIMARY KEY id
+        SOURCE(CLICKHOUSE(TABLE 'truncate_test'))
+        LIFETIME(MIN 0 MAX 0)
+        LAYOUT(FLAT())
+      SQL
+      connection.exec_insert("INSERT INTO truncate_test (id, name) VALUES (1, 'Alice')")
+
+      expect { connection.truncate_tables(*connection.tables) }.not_to raise_error
+
+      expect(connection.select_value('SELECT count() FROM truncate_test')).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## What Changed?

I added 
* `#build_truncate_statements`  - Update the functionality to filter out engines that cannot be truncated
* Added unit test to ensure functionality
* Added `clickhouse/minitest.rb` as a helper similar to `clickhouse/rspec.rb`

## Motivation

In our production app we're using [database_cleaner](https://github.com/DatabaseCleaner/database_cleaner) to do the truncation and taking advantage of it's `except` functionality (`DatabaseCleaner.strategy = [:truncation, except: %w[widgets]]`) to filter out specific tables. I'm hoping to remove our dependency on `database_cleaner` and allow `clickhouse-activerecord` to manage the truncation.

The pattern used here follows the ActiveRecord implementation. We currently rely on the abstract implementation for `#truncate` and `#truncate_tables` - [active_record/connection_adapters/abstract/database_statements.rb](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L270-L284).

Postgres and Sqlite use this same pattern to adjust their truncation methods
- [`postgresql/database_statements.rb`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/postgresql/database_statements.rb#L228-L230) - Overrides `build_truncate_statements` to truncate all tables in a single statement
- [`sqlite3/database_statements.rb`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/sqlite3/database_statements.rb#L163-L165) - Overrides `build_truncate_statement` to use `DELETE FROM` since SQLite doesn't support `TRUNCATE`

