### PR TITLE
Fix test helpers to restore original database connection

### DIFF
--- a/lib/clickhouse-activerecord/minitest.rb
+++ b/lib/clickhouse-activerecord/minitest.rb
@@ -4,10 +4,13 @@ module ClickhouseActiverecord
   module TestHelper
     def before_setup
       super
+      original_connection_config = ActiveRecord::Base.connection_db_config
       ActiveRecord::Base.configurations.configurations.select { |x| x.env_name == Rails.env && x.adapter == 'clickhouse' }.each do |config|
         ActiveRecord::Base.establish_connection(config)
         ActiveRecord::Base.connection.truncate_tables(*ActiveRecord::Base.connection.tables)
       end
+    ensure
+      ActiveRecord::Base.establish_connection(original_connection_config) if original_connection_config
     end
   end
 end

--- a/lib/clickhouse-activerecord/rspec.rb
+++ b/lib/clickhouse-activerecord/rspec.rb
@@ -2,9 +2,11 @@
 
 RSpec.configure do |config|
   config.before do
-    ActiveRecord::Base.configurations.configurations.select { |x| x.env_name == Rails.env && x.adapter == 'clickhouse' }.each do |config|
-      ActiveRecord::Base.establish_connection(config)
+    original_connection_config = ActiveRecord::Base.connection_db_config
+    ActiveRecord::Base.configurations.configurations.select { |x| x.env_name == Rails.env && x.adapter == 'clickhouse' }.each do |db_config|
+      ActiveRecord::Base.establish_connection(db_config)
       ActiveRecord::Base.connection.truncate_tables(*ActiveRecord::Base.connection.tables)
     end
+    ActiveRecord::Base.establish_connection(original_connection_config)
   end
 end


### PR DESCRIPTION
## Summary

The minitest and rspec test helpers change `ActiveRecord::Base.connection` to ClickHouse but never restore it afterward. This breaks multi-database Rails apps where the primary database is PostgreSQL/MySQL.

**Before:** After `before_setup` (minitest) or `before` (rspec) runs, `ActiveRecord::Base.connection` points to ClickHouse instead of the app's primary database.

**After:** The original connection is saved before truncating ClickHouse tables and restored afterward.

## Changes

- `lib/clickhouse-activerecord/minitest.rb`: Save connection config before iterating ClickHouse configs, restore in `ensure` block
- `lib/clickhouse-activerecord/rspec.rb`: Same fix, plus renamed block variable from `config` to `db_config` to avoid shadowing the outer `RSpec.configure` block variable

## Test plan

- [x] Verify in a multi-database Rails app that `ActiveRecord::Base.connection` remains pointed at the primary database after test setup runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)