### PR TITLE
Fix multi-column indexes in schema dumper

### DIFF
--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -99,7 +99,7 @@ module ClickhouseActiverecord
             end
           end
 
-          indexes = sql.scan(/INDEX \S+ \S+ TYPE .*? GRANULARITY \d+/)
+          indexes = sql.scan(/INDEX \S+ .+? TYPE .*? GRANULARITY \d+/)
           if indexes.any?
             tbl.puts ''
             indexes.flatten.map!(&:strip).each do |index|

--- a/spec/fixtures/migrations/dsl_create_table_with_index/4_create_simple_index.rb
+++ b/spec/fixtures/migrations/dsl_create_table_with_index/4_create_simple_index.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CreateSimpleIndex < ActiveRecord::Migration[7.1]
+  def up
+    add_index :some, 'date', name: 'simple_idx', type: 'minmax', granularity: 1
+  end
+end


### PR DESCRIPTION
Previously, multi-column and other complex index expressions would execute successfully, but they would not be dumped to the schema file. This resolves that issue by allowing more complex expressions to be used.

```rb
add_index :event_logs, "(resource_type, resource_id)", name: "idx_resource", type: "bloom_filter", granularity: 4
```

Now correctly results in the following being dumped:

```rb
t.index "(resource_type, resource_id)", name: "idx_resource", type: "bloom_filter", granularity: 4
```

Before, nothing was dumped.

