### PR TITLE
Fix TimeZoneConverter crash for Map OID attributes

### DIFF
--- a/lib/clickhouse-activerecord.rb
+++ b/lib/clickhouse-activerecord.rb
@@ -30,5 +30,15 @@ module ClickhouseActiverecord
     Arel::Nodes::SelectStatement.prepend(CoreExtensions::Arel::Nodes::SelectStatement)
     Arel::SelectManager.prepend(CoreExtensions::Arel::SelectManager)
     Arel::Table.prepend(CoreExtensions::Arel::Table)
+
+    # Prevent TimeZoneConverter wrapping for Map OID with DateTime subtype.
+    # Map(String, DateTime) would crash with "Hash values are not supported"
+    # when TimeZoneConverter tries to convert Hash values.
+    ActiveRecord::AttributeMethods::TimeZoneConversion::ClassMethods.prepend(Module.new do
+      def create_time_zone_conversion_attribute?(name, cast_type)
+        return false if cast_type.is_a?(ActiveRecord::ConnectionAdapters::Clickhouse::OID::Map)
+        super
+      end
+    end)
   end
 end

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -661,6 +661,33 @@ RSpec.describe 'Model', :migrations do
         expect(record.map_array_datetime['c'][1]).to eq(DateTime.parse('2024-01-01 12:00:08'))
       end
     end
+
+    describe 'TimeZoneConverter compatibility' do
+      it 'does not crash when time_zone_aware_attributes is enabled' do
+        Time.use_zone('UTC') do
+          ActiveRecord::Base.time_zone_aware_attributes = true
+          model.reset_column_information
+
+          begin
+            model.create!(
+              map_datetime: {a: Time.now},
+              map_string: {a: 'test'},
+              map_int: {a: 1},
+              map_array_datetime: {a: []},
+              map_array_string: {a: []},
+              map_array_int: {a: []},
+              date: Date.today
+            )
+
+            expect { model.first.map_datetime }.to_not raise_error
+            expect(model.first.map_datetime['a']).to be_a DateTime
+          ensure
+            ActiveRecord::Base.time_zone_aware_attributes = false
+            model.reset_column_information
+          end
+        end
+      end
+    end
   end
 
   if Model.connection.server_version.to_f > 24.6


### PR DESCRIPTION
## Problem

When time_zone_aware_attributes is enabled, ActiveRecord wraps datetime attributes with TimeZoneConverter. For Map(String, DateTime) columns this causes a crash:

```
 ArgumentError: Hash values are not supported
```

TimeZoneConverter tries to convert the Hash value directly instead of delegating to the Map OID type.

## Solution

Override create_time_zone_conversion_attribute? to return false for Map OID attributes, preventing TimeZoneConverter from wrapping them.

## Test

Added a spec that enables time_zone_aware_attributes = true with a timezone set, resets column info, then verifies that creating and reading a Map(String, DateTime) record does not raise.