### PR TITLE
Fix Map OID deserialize crash for already-parsed Date/DateTime values

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/oid/map.rb
+++ b/lib/active_record/connection_adapters/clickhouse/oid/map.rb
@@ -31,6 +31,7 @@ module ActiveRecord
               value.map { |item| deserialize(item) }
             else
               return value if value.nil?
+              return value if already_deserialized?(value)
               case @subtype
                 when :integer
                   value.to_i
@@ -67,6 +68,11 @@ module ActiveRecord
           end
 
           private
+
+          def already_deserialized?(value)
+            (@subtype == :date && value.is_a?(::Date)) ||
+              (@subtype == :datetime && (value.is_a?(::DateTime) || value.is_a?(::Time)))
+          end
 
           def bits_to_limit(bits)
             case bits

--- a/spec/fixtures/migrations/add_map_datetime/1_create_verbs_table.rb
+++ b/spec/fixtures/migrations/add_map_datetime/1_create_verbs_table.rb
@@ -2,6 +2,7 @@ class CreateVerbsTable < ActiveRecord::Migration[7.1]
   def up
     create_table :verbs, options: 'MergeTree ORDER BY date', force: true do |t|
       t.datetime :map_datetime, null: false, map: true
+      t.date :map_date, null: false, map: true
       t.string :map_string, null: false, map: true
       t.integer :map_int, null: false, map: true
 

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -660,6 +660,28 @@ RSpec.describe 'Model', :migrations do
         expect(record.map_array_datetime['c'][0]).to eq(DateTime.parse('2022-12-05 15:22:49'))
         expect(record.map_array_datetime['c'][1]).to eq(DateTime.parse('2024-01-01 12:00:08'))
       end
+
+      it 'handles already deserialized DateTime/Time map values without re-parsing' do
+        now = Time.now
+        instance = model.instantiate({
+          'id' => '1',
+          'map_datetime' => {'t1' => now, 't2' => DateTime.now},
+          'map_date' => {'d' => Date.current},
+          'map_string' => {'x' => 'test'},
+          'map_int' => {'n' => 1},
+          'map_array_datetime' => {'a' => []},
+          'map_array_string' => {'a' => []},
+          'map_array_int' => {'a' => []},
+          'date' => Date.today
+        })
+
+        expect { instance.map_datetime }.to_not raise_error
+        expect(instance.map_datetime['t1']).to be_a(Time).or be_a(DateTime)
+        expect(instance.map_datetime['t2']).to be_a DateTime
+
+        expect { instance.map_date }.to_not raise_error
+        expect(instance.map_date['d']).to be_a Date
+      end
     end
   end
 


### PR DESCRIPTION
When deserialize was called with an already-parsed DateTime or Time value (e.g. via model.instantiate), it would crash with:

```
TypeError: no implicit conversion of DateTime into String
```

because DateTime.parse was called on an object instead of a string.