### PR TITLE
Add configurable HTTP auth modes for ClickHouse requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,38 @@ Donations to this project are going directly to [PNixx](https://github.com/PNixx
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
+### Run locally
+
+1. Start ClickHouse (single node):
+
+```bash
+docker compose -f .docker/docker-compose.yml up -d
+```
+
+2. Run single-node specs:
+
+```bash
+bin/test-single
+```
+
+If your local workflow expects `bin/single_test`, use the same command format as `bin/test-single`:
+
+```bash
+CLICKHOUSE_PORT=18123 CLICKHOUSE_DATABASE=default bundle exec rspec spec/single --format progress
+```
+
+3. Start ClickHouse cluster:
+
+```bash
+docker compose -f .docker/docker-compose.cluster.yml up -d
+```
+
+4. Run cluster specs:
+
+```bash
+CLICKHOUSE_PORT=28123 CLICKHOUSE_DATABASE=default CLICKHOUSE_CLUSTER=test_cluster bundle exec rspec spec/cluster --format progress
+```
+
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 Testing github actions:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ default: &default
   port: 8123
   username: username
   password: password
+  http_auth: x_clickhouse_headers # optional, supports basic and x_clickhouse_headers
   ssl: true # optional for using ssl connection
   debug: true # use for showing in to log technical information
   migrations_paths: db/clickhouse # optional, default: db/migrate_clickhouse
@@ -52,6 +53,27 @@ class ActionView < ActiveRecord::Base
   )
 end
 ```
+
+### HTTP authentication mode
+
+By default, the adapter sends `user` and `password` as URL parameters.
+You can switch to header-based HTTP auth using `http_auth`:
+
+```yml
+clickhouse:
+  adapter: clickhouse
+  host: localhost
+  port: 8123
+  database: my_db
+  username: app_user
+  password: secret
+  http_auth: x_clickhouse_headers # or basic
+```
+
+- Use YAML string values: `http_auth: basic` or `http_auth: x_clickhouse_headers`.
+- Both strings and Ruby symbols are accepted internally.
+- `http_auth: basic` sends `Authorization: Basic ...` and keeps `database` in URL params.
+- `http_auth: x_clickhouse_headers` sends `X-ClickHouse-User`, `X-ClickHouse-Key`, and `X-ClickHouse-Database` headers.
 
 ## Usage in Rails
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ default: &default
   port: 8123
   username: username
   password: password
-  http_auth: x_clickhouse_headers # optional, supports basic and x_clickhouse_headers
+  http_auth: query_params # optional, supports query_params, basic, x_clickhouse_headers
   ssl: true # optional for using ssl connection
   debug: true # use for showing in to log technical information
   migrations_paths: db/clickhouse # optional, default: db/migrate_clickhouse
@@ -57,7 +57,7 @@ end
 ### HTTP authentication mode
 
 By default, the adapter sends `user` and `password` as URL parameters.
-You can switch to header-based HTTP auth using `http_auth`:
+You can set `http_auth` explicitly (or omit it and keep the same default behavior):
 
 ```yml
 clickhouse:
@@ -67,13 +67,14 @@ clickhouse:
   database: my_db
   username: app_user
   password: secret
-  http_auth: x_clickhouse_headers # or basic
+  http_auth: x_clickhouse_headers # or basic / query_params
 ```
 
-- Use YAML string values: `http_auth: basic` or `http_auth: x_clickhouse_headers`.
+- Use YAML string values: `http_auth: query_params`, `http_auth: basic`, or `http_auth: x_clickhouse_headers`.
 - Both strings and Ruby symbols are accepted internally.
-- `http_auth: basic` sends `Authorization: Basic ...` and keeps `database` in URL params.
 - `http_auth: x_clickhouse_headers` sends `X-ClickHouse-User`, `X-ClickHouse-Key`, and `X-ClickHouse-Database` headers.
+- `http_auth: basic` sends `Authorization: Basic ...` and keeps `database` in URL params.
+- `http_auth: query_params` sends `user`, `password`, and `database` in URL params (same as omitting `http_auth`).
 
 ## Usage in Rails
 

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "clickhouse/activerecord"
+require "clickhouse-activerecord"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/bin/test-single
+++ b/bin/test-single
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CLICKHOUSE_PORT="${CLICKHOUSE_PORT:-18123}"
+export CLICKHOUSE_DATABASE="${CLICKHOUSE_DATABASE:-default}"
+
+exec bundle exec rspec spec/single --format progress "$@"

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
+require 'base64'
 require 'clickhouse-activerecord/version'
 
 module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
       module SchemaStatements
+        HTTP_AUTH_BASIC = :basic
+        HTTP_AUTH_X_HEADERS = :x_clickhouse_headers
+        HTTP_AUTH_TYPES = [HTTP_AUTH_BASIC, HTTP_AUTH_X_HEADERS].freeze
 
         def with_settings(**settings)
           @block_settings ||= {}
@@ -61,10 +65,7 @@ module ActiveRecord
               statement = Statement.new(sql, format: @response_format)
               result = nil
               @lock.synchronize do
-                req = Net::HTTP::Post.new("/?#{settings_params(settings)}", {
-                  'Content-Type' => 'application/x-www-form-urlencoded',
-                  'User-Agent' => ClickhouseAdapter::USER_AGENT,
-                })
+                req = Net::HTTP::Post.new("/?#{settings_params(settings)}", build_request_headers)
                 @connection.start unless @connection.started?
                 @connection.request(req, statement.formatted_sql) do |response|
                   result = statement.streaming_response(response)
@@ -303,8 +304,7 @@ module ActiveRecord
           @lock.synchronize do
             @connection.post("/?#{settings_params(settings, except: except_params)}",
                              statement.formatted_sql,
-                             'Content-Type' => 'application/x-www-form-urlencoded',
-                             'User-Agent' => ClickhouseAdapter::USER_AGENT)
+                             build_request_headers(include_database: !except_params.include?(:database)))
           end
         end
 
@@ -316,10 +316,39 @@ module ActiveRecord
         def settings_params(settings = {}, except: [])
           request_params = @connection_config || {}
           block_settings = @block_settings || {}
+
+          case @http_auth
+          when HTTP_AUTH_BASIC
+            request_params = request_params.except(:user, :password)
+          when HTTP_AUTH_X_HEADERS
+            request_params = request_params.except(:user, :password, :database)
+          end
+
           request_params.merge(block_settings)
                         .merge(settings)
                         .except(*except)
                         .to_param
+        end
+
+        def build_request_headers(include_database: true)
+          request_headers = {
+            'Content-Type' => 'application/x-www-form-urlencoded',
+            'User-Agent' => ClickhouseAdapter::USER_AGENT
+          }
+
+          case @http_auth
+          when HTTP_AUTH_BASIC
+            if @config[:username] && @config[:password]
+              credentials = Base64.strict_encode64("#{@config[:username]}:#{@config[:password]}")
+              request_headers['Authorization'] = "Basic #{credentials}"
+            end
+          when HTTP_AUTH_X_HEADERS
+            request_headers['X-ClickHouse-User'] = @config[:username].to_s if @config[:username]
+            request_headers['X-ClickHouse-Key'] = @config[:password].to_s if @config[:password]
+            request_headers['X-ClickHouse-Database'] = @config[:database].to_s if include_database && @config[:database]
+          end
+
+          request_headers
         end
 
         # Returns a hash of table names to their engine types

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -7,9 +7,10 @@ module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
       module SchemaStatements
+        HTTP_AUTH_QUERY_PARAMS = :query_params
         HTTP_AUTH_BASIC = :basic
         HTTP_AUTH_X_HEADERS = :x_clickhouse_headers
-        HTTP_AUTH_TYPES = [HTTP_AUTH_BASIC, HTTP_AUTH_X_HEADERS].freeze
+        HTTP_AUTH_TYPES = [HTTP_AUTH_QUERY_PARAMS, HTTP_AUTH_BASIC, HTTP_AUTH_X_HEADERS].freeze
 
         def with_settings(**settings)
           @block_settings ||= {}

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -32,6 +32,13 @@ module ActiveRecord
           raise ArgumentError, 'No database specified. Missing argument: database.'
         end
 
+        if config[:http_auth]
+          unless ConnectionAdapters::Clickhouse::SchemaStatements::HTTP_AUTH_TYPES.include?(config[:http_auth]&.to_sym)
+            raise ArgumentError, "Unknown :http_auth mode #{config[:http_auth].inspect}. " \
+              + "Use one of #{ConnectionAdapters::Clickhouse::SchemaStatements::HTTP_AUTH_TYPES}."
+          end
+        end
+
         ConnectionAdapters::ClickhouseAdapter.new(config)
       end
     end
@@ -143,6 +150,7 @@ module ActiveRecord
         @connection_config = { user: @config[:username], password: @config[:password], database: @config[:database] }.compact
         @debug = @config[:debug] || false
         @response_format = @config[:format] || DEFAULT_RESPONSE_FORMAT
+        @http_auth = @config[:http_auth]&.to_sym
 
         @prepared_statements = false
 

--- a/spec/single/http_auth_spec.rb
+++ b/spec/single/http_auth_spec.rb
@@ -67,6 +67,39 @@ RSpec.describe 'HTTP auth modes' do
     end
   end
 
+  context 'query params mode' do
+    let(:config) { base_config.merge(http_auth: :query_params) }
+
+    it 'uses url query auth explicitly' do
+      payload = request_payload_for
+
+      expect(payload[:query_params]).to include(
+        'user' => config[:username],
+        'password' => config[:password],
+        'database' => config[:database],
+        'max_threads' => request_settings[:max_threads].to_s
+      )
+      expect(payload[:headers]).to_not have_key('Authorization')
+      expect(payload[:headers]).to_not have_key('X-ClickHouse-User')
+    end
+
+    context 'mode as string' do
+      let(:config) { base_config.merge(http_auth: 'query_params') }
+
+      it 'uses url query auth explicitly' do
+        payload = request_payload_for
+
+        expect(payload[:query_params]).to include(
+          'user' => config[:username],
+          'password' => config[:password],
+          'database' => config[:database]
+        )
+        expect(payload[:headers]).to_not have_key('Authorization')
+        expect(payload[:headers]).to_not have_key('X-ClickHouse-User')
+      end
+    end
+  end
+
   context 'basic auth mode' do
     let(:config) { base_config.merge(http_auth: :basic) }
 

--- a/spec/single/http_auth_spec.rb
+++ b/spec/single/http_auth_spec.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'uri'
+
+RSpec.describe 'HTTP auth modes' do
+  let(:http_connection) { instance_double(Net::HTTP) }
+  let(:response_body) { '' }
+  let(:response) { instance_double(Net::HTTPResponse, code: '200', body: response_body) }
+  let(:base_config) do
+    {
+      adapter: 'clickhouse',
+      host: 'localhost',
+      port: 8123,
+      database: 'test_db',
+      username: 'app_user',
+      password: 'secret'
+    }
+  end
+  let(:request_settings) { { max_threads: 1 } }
+  let(:target_database) { 'analytics' }
+  let(:config) { base_config }
+  subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+  before do
+    allow(Net::HTTP).to receive(:start).and_return(http_connection)
+    allow(http_connection).to receive(:keep_alive_timeout=)
+    allow(http_connection).to receive(:started?).and_return(true)
+    allow(http_connection).to receive(:post).and_return(response)
+  end
+
+  def request_payload_for(settings: request_settings)
+    request_payload = {}
+
+    allow(http_connection).to receive(:post) do |path, _body, headers|
+      request_payload[:query_params] = query_params(path)
+      request_payload[:headers] = headers
+
+      response
+    end
+
+    adapter.execute('SELECT 1', settings: settings)
+    request_payload
+  end
+
+  def query_params(path)
+    query = path.split('?', 2).last.to_s
+    URI.decode_www_form(query).to_h
+  end
+
+  def json_compact_each_row(names:, types:, rows:)
+    ([names, types] + rows).map(&:to_json).join("\n")
+  end
+
+  context 'default mode' do
+    it 'uses url query auth' do
+      payload = request_payload_for
+
+      expect(payload[:query_params]).to include(
+        'user' => config[:username],
+        'password' => config[:password],
+        'database' => config[:database],
+        'max_threads' => request_settings[:max_threads].to_s
+      )
+      expect(payload[:headers]).to_not have_key('Authorization')
+      expect(payload[:headers]).to_not have_key('X-ClickHouse-User')
+    end
+  end
+
+  context 'basic auth mode' do
+    let(:config) { base_config.merge(http_auth: :basic) }
+
+    it 'uses Authorization header' do
+      payload = request_payload_for
+
+      expect(payload[:query_params]).to include(
+        'database' => config[:database],
+        'max_threads' => request_settings[:max_threads].to_s
+      )
+      expect(payload[:query_params]).to_not have_key('user')
+      expect(payload[:query_params]).to_not have_key('password')
+      expect(payload[:headers]['Authorization']).to eq("Basic #{Base64.strict_encode64("#{config[:username]}:#{config[:password]}")}")
+    end
+
+    it 'uses Authorization header for create_database' do
+      adapter.create_database(target_database)
+
+      expect(http_connection).to have_received(:post) do |path, _body, headers|
+        params = query_params(path)
+
+        expect(params).to_not have_key('user')
+        expect(params).to_not have_key('password')
+        expect(params).to_not have_key('database')
+        expect(headers['Authorization']).to eq("Basic #{Base64.strict_encode64("#{config[:username]}:#{config[:password]}")}")
+      end
+    end
+
+    it 'uses Authorization header for drop_database' do
+      adapter.drop_database(target_database)
+
+      expect(http_connection).to have_received(:post) do |path, _body, headers|
+        params = query_params(path)
+
+        expect(params).to_not have_key('user')
+        expect(params).to_not have_key('password')
+        expect(params).to_not have_key('database')
+        expect(headers['Authorization']).to eq("Basic #{Base64.strict_encode64("#{config[:username]}:#{config[:password]}")}")
+      end
+    end
+
+    it 'uses Authorization header for system queries' do
+      allow(http_connection).to receive(:post) do |path, _body, headers|
+        expect(query_params(path)).to_not have_key('user')
+        expect(query_params(path)).to_not have_key('password')
+        expect(headers['Authorization']).to eq("Basic #{Base64.strict_encode64("#{config[:username]}:#{config[:password]}")}")
+        instance_double(Net::HTTPResponse, code: '200',
+                                           body: json_compact_each_row(names: ['name'], types: ['String'], rows: [['events']]))
+      end
+
+      expect(adapter.tables).to eq(['events'])
+      expect(adapter.views).to eq(['events'])
+    end
+
+    context 'mode as string' do
+      let(:config) { base_config.merge(http_auth: 'basic') }
+
+      it 'uses Authorization header' do
+        payload = request_payload_for
+
+        expect(payload[:query_params]).to_not have_key('user')
+        expect(payload[:query_params]).to_not have_key('password')
+        expect(payload[:headers]['Authorization']).to eq("Basic #{Base64.strict_encode64("#{config[:username]}:#{config[:password]}")}")
+      end
+    end
+
+    context 'without username/password' do
+      let(:config) { base_config.merge(username: nil, password: nil, http_auth: :basic) }
+
+      it 'does not send Authorization header' do
+        payload = request_payload_for
+
+        expect(payload[:query_params]).to include(
+          'database' => config[:database],
+          'max_threads' => request_settings[:max_threads].to_s
+        )
+        expect(payload[:query_params]).to_not have_key('user')
+        expect(payload[:query_params]).to_not have_key('password')
+        expect(payload[:headers]).to_not have_key('Authorization')
+      end
+    end
+  end
+
+  context 'x-clickhouse headers mode' do
+    let(:config) { base_config.merge(http_auth: :x_clickhouse_headers) }
+
+    it 'uses X-ClickHouse auth headers' do
+      payload = request_payload_for
+
+      expect(payload[:query_params]).to include('max_threads' => request_settings[:max_threads].to_s)
+      expect(payload[:query_params]).to_not have_key('user')
+      expect(payload[:query_params]).to_not have_key('password')
+      expect(payload[:query_params]).to_not have_key('database')
+
+      expect(payload[:headers]).to include(
+        'X-ClickHouse-User' => config[:username],
+        'X-ClickHouse-Key' => config[:password],
+        'X-ClickHouse-Database' => config[:database]
+      )
+    end
+
+    context 'mode as string' do
+      let(:config) { base_config.merge(http_auth: 'x_clickhouse_headers') }
+
+      it 'uses X-ClickHouse auth headers' do
+        payload = request_payload_for
+
+        expect(payload[:query_params]).to_not have_key('user')
+        expect(payload[:query_params]).to_not have_key('password')
+        expect(payload[:query_params]).to_not have_key('database')
+
+        expect(payload[:headers]).to include(
+          'X-ClickHouse-User' => config[:username],
+          'X-ClickHouse-Key' => config[:password],
+          'X-ClickHouse-Database' => config[:database]
+        )
+      end
+    end
+
+    it 'does not include database auth context for create_database' do
+      adapter.create_database(target_database)
+
+      expect(http_connection).to have_received(:post) do |_path, _body, headers|
+        expect(headers).to_not have_key('X-ClickHouse-Database')
+
+        expect(headers).to include(
+          'X-ClickHouse-User' => config[:username],
+          'X-ClickHouse-Key' => config[:password]
+        )
+      end
+    end
+
+    it 'does not include database auth context for drop_database' do
+      adapter.drop_database(target_database)
+
+      expect(http_connection).to have_received(:post) do |_path, _body, headers|
+        expect(headers).to_not have_key('X-ClickHouse-Database')
+
+        expect(headers).to include(
+          'X-ClickHouse-User' => config[:username],
+          'X-ClickHouse-Key' => config[:password]
+        )
+      end
+    end
+
+    it 'uses auth headers for execute_to_file requests' do
+      streaming_response = instance_double(Net::HTTPResponse, code: '200')
+
+      allow(http_connection).to receive(:request) do |request, _sql, &callback|
+        params = query_params(request.path)
+        expect(params).to include('max_threads' => request_settings[:max_threads].to_s)
+        expect(params).to_not have_key('user')
+        expect(params).to_not have_key('password')
+        expect(params).to_not have_key('database')
+
+        expect(request['X-ClickHouse-User']).to eq(config[:username])
+        expect(request['X-ClickHouse-Key']).to eq(config[:password])
+        expect(request['X-ClickHouse-Database']).to eq(config[:database])
+
+        allow(streaming_response).to receive(:read_body).and_yield("id\n1\n")
+        callback.call(streaming_response)
+      end
+
+      file = adapter.execute_to_file('SELECT 1', settings: request_settings)
+      expect(file.read).to eq("id\n1\n")
+      file.close!
+    end
+
+    context 'without username/password' do
+      let(:config) { base_config.merge(username: nil, password: nil, http_auth: :x_clickhouse_headers) }
+
+      it 'does not send empty auth headers' do
+        payload = request_payload_for
+
+        expect(payload[:query_params]).to include('max_threads' => request_settings[:max_threads].to_s)
+        expect(payload[:query_params]).to_not have_key('user')
+        expect(payload[:query_params]).to_not have_key('password')
+        expect(payload[:query_params]).to_not have_key('database')
+
+        expect(payload[:headers]).to_not have_key('X-ClickHouse-User')
+        expect(payload[:headers]).to_not have_key('X-ClickHouse-Key')
+        expect(payload[:headers]['X-ClickHouse-Database']).to eq(config[:database])
+      end
+    end
+  end
+
+  context 'invalid mode' do
+    it 'raises argument error' do
+      expect do
+        ActiveRecord::Base.clickhouse_connection(base_config.merge(http_auth: :unsupported))
+      end.to raise_error(ArgumentError, /Unknown :http_auth mode/)
+    end
+  end
+end


### PR DESCRIPTION
## Problem
The adapter currently sends ClickHouse credentials as URL query parameters by default, which can leak sensitive data via logs/proxies and is hard to avoid in some environments.  
This addresses #236 while keeping existing behavior compatible.

## Changes
- Added configurable `http_auth` modes:
  - `query_params` (user and password as query params)
  - `basic` (HTTP Basic Authorization header)
  - `x_clickhouse_headers` (`X-ClickHouse-User`, `X-ClickHouse-Key`, and database header when applicable)
- Kept the existing query-param auth as the default for backward compatibility.
- Applied behavior consistently across request paths, including regular execute calls, system queries (`tables`/`views`), create/drop database flows, and `execute_to_file`
- Improves local dev/test instructions (single and cluster with `docker-compose`, plus `bin/test-single`)

## Local test

To ensure the behavior, the requests to Clickhouse were intercepted

```bash
# Default option

b..y.o..POST /?database=<REDACTED>&password=<REDACTED>&user=<REDACTED> HTTP/1.1
User-Agent: Clickhouse ActiveRecord 1.6.7
Content-Type: application/x-www-form-urlencoded
Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3
Accept: */*
Traceparent: <REDACTED>
Host: <REDACTED>
Content-Length: 75

# With x_clickhouse_headers

.H...2..POST /? HTTP/1.1
User-Agent: Clickhouse ActiveRecord 1.6.7
Content-Type: application/x-www-form-urlencoded
X-Clickhouse-User: <REDACTED>
X-Clickhouse-Key: <REDACTED>
X-Clickhouse-Database: <REDACTED>
Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3
Accept: */*
Traceparent: <REDACTED>
Host: <REDACTED>
Content-Length: 75
```