### PR TITLE
Fix stale HTTP connections causing EOFError on idle connections

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -61,14 +61,16 @@ module ActiveRecord
               statement = Statement.new(sql, format: @response_format)
               result = nil
               @lock.synchronize do
+                ensure_connection_active!
+
                 req = Net::HTTP::Post.new("/?#{settings_params(settings)}", {
                   'Content-Type' => 'application/x-www-form-urlencoded',
                   'User-Agent' => ClickhouseAdapter::USER_AGENT,
                 })
-                @connection.start unless @connection.started?
                 @connection.request(req, statement.formatted_sql) do |response|
                   result = statement.streaming_response(response)
                 end
+                @last_request_at = Time.now
               end
               result
             end
@@ -294,17 +296,23 @@ module ActiveRecord
           statement.processed_response(response)
         end
 
-        # Make HTTP request to ClickHouse server
+        # Make HTTP request to ClickHouse server.
+        # Checks that the connection is still alive before sending the request,
+        # reconnecting proactively if it has been idle longer than keep_alive_timeout.
         # @param [ActiveRecord::ConnectionAdapters::Clickhouse::Statement] statement
         # @param [Hash] settings
         # @param [Array] except_params
         # @return [Net::HTTPResponse]
         def request(statement, settings: {}, except_params: [])
           @lock.synchronize do
-            @connection.post("/?#{settings_params(settings, except: except_params)}",
+            ensure_connection_active!
+
+            response = @connection.post("/?#{settings_params(settings, except: except_params)}",
                              statement.formatted_sql,
                              'Content-Type' => 'application/x-www-form-urlencoded',
                              'User-Agent' => ClickhouseAdapter::USER_AGENT)
+            @last_request_at = Time.now
+            response
           end
         end
 

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -151,6 +151,7 @@ module ActiveRecord
 
       def disconnect!
         @connection.finish if @connection&.started?
+        @last_request_at = nil
         super
       end
 
@@ -561,11 +562,29 @@ module ActiveRecord
         # Use clickhouse default keep_alive_timeout value of 10, rather than Net::HTTP's default of 2
         @connection.keep_alive_timeout = @connection_parameters[:keep_alive_timeout] || 10
 
+        @last_request_at = nil
         @connection
       end
 
       def reconnect
         connect
+      end
+
+      # Returns true if the connection has been idle for less than keep_alive_timeout.
+      # When the connection has been idle longer, the server may have already closed it,
+      # and reusing it would result in an EOFError.
+      def connection_fresh?
+        return true unless @last_request_at
+
+        keep_alive = @connection_parameters[:keep_alive_timeout] || 10
+        (Time.now - @last_request_at) < keep_alive
+      end
+
+      # Ensures the connection is active and fresh before making a request.
+      # Reconnects proactively if the connection is not started or has been idle
+      # longer than the keep_alive_timeout.
+      def ensure_connection_active!
+        reconnect unless @connection&.started? && connection_fresh?
       end
 
       def apply_replica(table, options)


### PR DESCRIPTION
I've been running into intermittent `EOFError` exceptions when using the adapter with ClickHouse Cloud. After some investigation, I traced it to stale HTTP connections being reused after the server has already closed them.

The adapter sets `keep_alive_timeout` on the `Net::HTTP` object, but nothing actually checks that value before reusing the connection. So if there's a gap between requests longer than the server's keep-alive timeout, the next query hits a dead socket:

```
net-protocol-0.2.2/lib/net/protocol.rb:237:in `rbuf_fill': end of file reached (EOFError)
```

This is especially common with ClickHouse Cloud or when there's a load balancer in between, since those tend to have their own idle timeouts.

This PR tracks when the last request was made and checks before each new request whether the connection has been idle longer than `keep_alive_timeout`. If it has, reconnects before sending, so we never try to use a connection the server may have already dropped.