### PR TITLE
Add SETTINGS to table DSL

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/column.rb
+++ b/lib/active_record/connection_adapters/clickhouse/column.rb
@@ -3,11 +3,12 @@ module ActiveRecord
     module Clickhouse
       class Column < ActiveRecord::ConnectionAdapters::Column
 
-        attr_reader :codec
+        attr_reader :codec, :ttl
 
-        def initialize(*, codec: nil, **)
+        def initialize(*, codec: nil, ttl: nil, **)
           super
           @codec = codec
+          @ttl = ttl
         end
 
         private

--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -42,6 +42,9 @@ module ActiveRecord
           if options[:codec]
             sql.gsub!(/\s+(.*)/, " \\1 CODEC(#{options[:codec]})")
           end
+          if options[:ttl]
+            sql.gsub!(/\s+(.*)/, " \\1 TTL #{options[:ttl]}")
+          end
           sql.gsub!(/(\sString)\(\d+\)/, '\1')
 
           if ::ActiveRecord::version >= Gem::Version.new('8.1')
@@ -66,6 +69,13 @@ module ActiveRecord
           end
 
           create_sql
+        end
+
+        def add_ttl_clause!(create_sql, options)
+          ttl = options.respond_to?(:ttl) ? options.ttl : options[:ttl]
+          return unless ttl.present?
+
+          create_sql << " TTL #{ttl}"
         end
 
         def add_as_clause!(create_sql, options)
@@ -121,6 +131,7 @@ module ActiveRecord
           # Attach options for only table or materialized view without TO section
           add_table_options!(create_sql, o) if !o.view || o.view && o.materialized && !o.to
           add_as_clause!(create_sql, o) if o.as && o.view
+          add_ttl_clause!(create_sql, o) if o.ttl
           create_sql
         end
 

--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -78,6 +78,13 @@ module ActiveRecord
           create_sql << " TTL #{ttl}"
         end
 
+        def add_settings_clause!(create_sql, options)
+          settings = options.respond_to?(:settings) ? options.settings : options[:settings]
+          return unless settings.present?
+
+          create_sql << " SETTINGS #{settings}"
+        end
+
         def add_as_clause!(create_sql, options)
           return unless options.as
 
@@ -132,6 +139,7 @@ module ActiveRecord
           add_table_options!(create_sql, o) if !o.view || o.view && o.materialized && !o.to
           add_as_clause!(create_sql, o) if o.as && o.view
           add_ttl_clause!(create_sql, o) if o.ttl
+          add_settings_clause!(create_sql, o) if o.settings
           create_sql
         end
 

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -245,7 +245,7 @@ module ActiveRecord
           args << cast_type if ::ActiveRecord::version >= Gem::Version.new('8.1')
           args += [default_value, type_metadata, field[1].include?('Nullable'), default_function]
 
-          Clickhouse::Column.new(*args, codec: field[5].presence)
+          Clickhouse::Column.new(*args, codec: field[5].presence, ttl: field[6].presence)
         end
 
         def extract_value_from_default(default_expression, default_type)

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -157,7 +157,29 @@ module ActiveRecord
 
         def table_options(table)
           sql = show_create_table(table)
-          { options: sql.gsub(/^(?:.*?)(?:ENGINE = (.*?))?( AS SELECT .*?)?$/, '\\1').presence, as: sql.match(/^CREATE (?:.*?) AS (SELECT .*?)$/).try(:[], 1) }.compact
+          result = {}
+
+          result[:as] = sql.match(/^CREATE (?:.*?) AS (SELECT .*?)$/).try(:[], 1)
+
+          engine_part = sql.gsub(/^(?:.*?)(?:ENGINE = (.*?))?( AS SELECT .*?)?$/, '\\1').presence
+
+          if engine_part
+            # Extract SETTINGS (always last if present)
+            if (settings_match = engine_part.match(/\s+SETTINGS\s+(.+)$/i))
+              result[:settings] = settings_match[1].strip
+              engine_part = engine_part[0...settings_match.begin(0)]
+            end
+
+            # Extract TTL (between engine/ordering clauses and SETTINGS)
+            if (ttl_match = engine_part.match(/\s+TTL\s+(.+)$/i))
+              result[:ttl] = ttl_match[1].strip
+              engine_part = engine_part[0...ttl_match.begin(0)]
+            end
+
+            result[:options] = engine_part.presence
+          end
+
+          result.compact
         end
 
         # Not indexes on clickhouse

--- a/lib/active_record/connection_adapters/clickhouse/table_definition.rb
+++ b/lib/active_record/connection_adapters/clickhouse/table_definition.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module Clickhouse
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
 
-        attr_reader :view, :materialized, :if_not_exists, :to
+        attr_reader :view, :materialized, :if_not_exists, :to, :ttl
 
         def initialize(
             conn,
@@ -18,6 +18,7 @@ module ActiveRecord
             view: false,
             materialized: false,
             to: nil,
+            ttl: nil,
             **
           )
           @conn = conn
@@ -34,6 +35,7 @@ module ActiveRecord
           @view = view || materialized
           @materialized = materialized
           @to = to
+          @ttl = ttl
         end
 
         def integer(*args, **options)
@@ -102,7 +104,7 @@ module ActiveRecord
         private
 
         def valid_column_definition_options
-          super + [:array, :low_cardinality, :fixed_string, :value, :type, :map, :codec, :unsigned]
+          super + [:array, :low_cardinality, :fixed_string, :value, :type, :map, :codec, :unsigned, :ttl]
         end
       end
 

--- a/lib/active_record/connection_adapters/clickhouse/table_definition.rb
+++ b/lib/active_record/connection_adapters/clickhouse/table_definition.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module Clickhouse
       class TableDefinition < ActiveRecord::ConnectionAdapters::TableDefinition
 
-        attr_reader :view, :materialized, :if_not_exists, :to, :ttl
+        attr_reader :view, :materialized, :if_not_exists, :to, :ttl, :settings
 
         def initialize(
             conn,
@@ -19,6 +19,7 @@ module ActiveRecord
             materialized: false,
             to: nil,
             ttl: nil,
+            settings: nil,
             **
           )
           @conn = conn
@@ -36,6 +37,7 @@ module ActiveRecord
           @materialized = materialized
           @to = to
           @ttl = ttl
+          @settings = settings
         end
 
         def integer(*args, **options)

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -185,6 +185,7 @@ module ClickhouseActiverecord
       end
       spec[:low_cardinality] = schema_low_cardinality(column)
       spec[:codec] = column.codec.inspect if column.codec
+      spec[:ttl] = column.ttl.inspect if column.ttl
       spec.merge(super).compact
     end
 

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -99,7 +99,7 @@ module ClickhouseActiverecord
             end
           end
 
-          indexes = sql.scan(/INDEX \S+ \S+ TYPE .*? GRANULARITY \d+/)
+          indexes = sql.scan(/INDEX \S+ .+? TYPE .*? GRANULARITY \d+/)
           if indexes.any?
             tbl.puts ''
             indexes.flatten.map!(&:strip).each do |index|

--- a/spec/fixtures/migrations/dsl_table_with_settings/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_table_with_settings/1_create_some_table.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateSomeTable < ActiveRecord::Migration[7.1]
+  def up
+    create_table :some, id: false, options: 'MergeTree ORDER BY an_id', ttl: 'date + INTERVAL 30 DAY', settings: 'allow_nullable_key = 1, index_granularity = 8192' do |t|
+      t.uuid :an_id, null: true
+      t.date :date, null: false
+      t.integer :data, null: false
+    end
+  end
+end

--- a/spec/fixtures/migrations/dsl_table_with_ttl/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_table_with_ttl/1_create_some_table.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateSomeTable < ActiveRecord::Migration[7.1]
+  def up
+    create_table :some, id: false, options: 'MergeTree ORDER BY date', ttl: 'date + INTERVAL 30 DAY' do |t|
+      t.date :date, null: false
+      t.integer :data, null: false, ttl: 'date + INTERVAL 1 DAY'
+    end
+  end
+end

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -144,6 +144,26 @@ RSpec.describe 'Migration', :migrations do
             end
           end
 
+          context 'ttl' do
+            let(:directory) { 'dsl_table_with_ttl' }
+            it 'creates a table with table-level and column-level TTL' do
+              subject
+
+              current_schema = schema(model)
+
+              expect(current_schema.keys.count).to eq(2)
+              expect(current_schema).to have_key('date')
+              expect(current_schema).to have_key('data')
+              expect(current_schema['date'].sql_type).to eq('Date')
+              expect(current_schema['data'].sql_type).to eq('UInt32')
+              expect(current_schema['data'].ttl).to eq('date + toIntervalDay(1)')
+
+              # Verify table-level TTL in SHOW CREATE TABLE
+              create_sql = ActiveRecord::Base.connection.show_create_table('some')
+              expect(create_sql).to include('TTL date + toIntervalDay(30)')
+            end
+          end
+
           context 'datetime' do
             let(:directory) { 'dsl_table_with_datetime_creation' }
             it 'creates a table with datetime columns' do

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe 'Migration', :migrations do
 
           context 'ttl' do
             let(:directory) { 'dsl_table_with_ttl' }
+
             it 'creates a table with table-level and column-level TTL' do
               subject
 
@@ -161,6 +162,63 @@ RSpec.describe 'Migration', :migrations do
               # Verify table-level TTL in SHOW CREATE TABLE
               create_sql = ActiveRecord::Base.connection.show_create_table('some')
               expect(create_sql).to include('TTL date + toIntervalDay(30)')
+            end
+
+            it 'creates a table with TTL using correct statement order' do
+              subject
+
+              current_schema = schema(model)
+
+              # Verify TTL comes after ENGINE
+              create_sql = ActiveRecord::Base.connection.show_create_table('some')
+              engine_idx = create_sql.index('ENGINE = MergeTree')
+              ttl_idx = create_sql.index('TTL date + toIntervalDay(30)')
+              expect(engine_idx).to be < ttl_idx
+            end
+          end
+
+          context 'settings' do
+            let(:directory) { 'dsl_table_with_settings' }
+
+            it 'creates a table with table-level SETTINGS' do
+              subject
+
+              current_schema = schema(model)
+
+              expect(current_schema.keys.count).to eq(3)
+              expect(current_schema).to have_key('an_id')
+              expect(current_schema).to have_key('date')
+              expect(current_schema).to have_key('data')
+
+              # Verify table-level SETTINGS in SHOW CREATE TABLE
+              create_sql = ActiveRecord::Base.connection.show_create_table('some')
+              expect(create_sql).to include('SETTINGS allow_nullable_key = 1, index_granularity = 8192')
+            end
+
+            it 'creates a table with SETTINGS using correct statement order' do
+              subject
+
+              current_schema = schema(model)
+
+              # Verify TTL comes before SETTINGS
+              create_sql = ActiveRecord::Base.connection.show_create_table('some')
+              ttl_idx = create_sql.index('TTL date')
+              settings_idx = create_sql.index('SETTINGS')
+              expect(ttl_idx).to be < settings_idx
+            end
+
+            it 'dumps SETTINGS as separate option' do
+              require 'clickhouse-activerecord/schema_dumper'
+
+              subject
+
+              schema = StringIO.new
+              ClickhouseActiverecord::SchemaDumper.dump(ActiveRecord::Base.connection, schema)
+              schema_string = schema.string
+
+              expect(schema_string).to include('options: "MergeTree ORDER BY an_id"')
+              expect(schema_string).to include('ttl: "date + toIntervalDay(30)"')
+              expect(schema_string).to include('settings: "allow_nullable_key = 1, index_granularity = 8192"')
             end
           end
 


### PR DESCRIPTION
With #233, if we specify `SETTINGS` in `options`, the generated statement is invalid since `SETTINGS` must come after `TTL`. This adds a separate option, `settings`, for providing table-level `SETTINGS`.