### PR TITLE
Rails 8 compatibility fixes

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -547,8 +547,13 @@ module ActiveRecord
 
       protected
 
-      def last_inserted_id(result)
-        result
+      def last_inserted_id(_result)
+        # Rails 7.1 persistence.rb:1258:
+        # _write_attribute(column, value)  # wrote true directly — ugly but no crash
+
+        # Rails 8.0 persistence.rb:933:
+        # _write_attribute(column, type_for_attribute(column).deserialize(value))  # now deserializes first
+        nil
       end
 
       def change_column_for_alter(table_name, column_name, type, **options)

--- a/lib/arel/visitors/clickhouse.rb
+++ b/lib/arel/visitors/clickhouse.rb
@@ -10,8 +10,7 @@ module Arel
       end
 
       def aggregate(name, o, collector)
-        # replacing function name for materialized view
-        if o.expressions.first && o.expressions.first != '*' && !o.expressions.first.is_a?(String) && o.expressions.first.relation&.is_view
+        if o.expressions.first && o.expressions.first != '*' && !o.expressions.first.is_a?(String) && o.expressions.first.respond_to?(:relation) && o.expressions.first.relation&.is_view
           super("#{name.downcase}Merge", o, collector)
         else
           super

--- a/lib/arel/visitors/clickhouse.rb
+++ b/lib/arel/visitors/clickhouse.rb
@@ -99,7 +99,7 @@ module Arel
         collector << "SETTINGS "
         o.expr.each_with_index do |(key, value), i|
           collector << ", " if i > 0
-          collector << key.to_s.gsub(/\W+/, "")
+          collector << sanitize_as_setting_name(key).to_s
           collector << " = "
           collector << sanitize_as_setting_value(value)
         end
@@ -145,7 +145,7 @@ module Arel
 
       def sanitize_as_setting_name(value)
         return value if Arel::Nodes::SqlLiteral === value
-        @connection.sanitize_as_setting_name(value)
+        value.to_s.gsub(/\W+/, "")
       end
 
       private

--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -34,28 +34,32 @@ module ClickhouseActiverecord
       create
     end
 
-    def structure_dump(*args)
+    def structure_dump(path, *)
       establish_master_connection
 
-      # get all tables
-      tables = connection.execute("SHOW TABLES FROM #{@configuration.database} WHERE name NOT LIKE '.inner_id.%'")['data'].flatten.map do |table|
-        connection.show_create_table(table, single_line: false).gsub("#{@configuration.database}.", '')
-      end.compact
-
-      # sort view to last
-      tables.sort_by! {|table| table.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) ? 1 : 0}
-
       # get all functions
-      functions = connection.execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name")['data'].flatten
+      functions = connection.execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name")['data']
+                            .flatten
+                            .map { |function| function.gsub('\\n', "\n") }
 
-      # put to file
-      File.open(args.first, 'w:utf-8') do |file|
-        functions.each do |function|
-          file.puts function.gsub('\\n', "\n") + ";\n\n"
-        end
+      # get all tables
+      table_defs = connection.execute("SHOW TABLES FROM #{@configuration.database} WHERE name NOT LIKE '.inner_id.%'")['data']
+                             .flatten
+                             .map { |name| connection.show_create_table(name, single_line: false).gsub("#{@configuration.database}.", '') }
 
-        tables.each do |table|
-          file.puts table + ";\n\n"
+      # separate views from tables
+      views, tables = table_defs.partition { |sql| sql.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) }
+
+      # separate materialized from regular views
+      mat_views, views = views.partition { |sql| sql.match(/^CREATE\s+MATERIALIZED\s+VIEW/) }
+
+      # sort: UDFs -> materialized views -> tables -> views
+      ordered_definitions = functions.sort + mat_views.sort + tables.sort + views.sort
+
+      # puts to file
+      File.open(path, 'w:utf-8') do |file|
+        ordered_definitions.each do |sql|
+          file.puts "#{sql};\n\n"
         end
       end
     end

--- a/spec/cluster/migration_spec.rb
+++ b/spec/cluster/migration_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Cluster Migration', :migrations do
+RSpec.describe 'Cluster Migration', :migrations, cluster: true do
   describe 'performs migrations' do
     let(:model) do
       Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
* Return `nil` in `last_inserted_id` instead of stashing the entire response object as an attribute (which Rails 7.2 permitted).
* Fix setting name sanitization.
* Sort functions -> matviews -> tables -> views in structure dump.