### PR TITLE
Parse column `DEFAULT` kinds

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/column.rb
+++ b/lib/active_record/connection_adapters/clickhouse/column.rb
@@ -2,12 +2,16 @@ module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
       class Column < ActiveRecord::ConnectionAdapters::Column
+        attr_reader :codec, :default_kind
 
-        attr_reader :codec
-
-        def initialize(*, codec: nil, **)
+        def initialize(*, codec: nil, default_kind: nil, **)
           super
           @codec = codec
+          @default_kind = ActiveSupport::StringInquirer.new(default_kind.to_s.downcase.presence || 'none')
+        end
+
+        def virtual?
+          default_kind.materialized? || default_kind.alias?
         end
 
         private

--- a/lib/active_record/connection_adapters/clickhouse/column.rb
+++ b/lib/active_record/connection_adapters/clickhouse/column.rb
@@ -1,6 +1,13 @@
 module ActiveRecord
   module ConnectionAdapters
     module Clickhouse
+      DescribedColumn =
+        Data.define(:name, :sql_type, :default_type, :default_expression, :comment, :codec) do
+          def ephemeral?
+            default_type.to_s.downcase == 'ephemeral'
+          end
+        end
+
       class Column < ActiveRecord::ConnectionAdapters::Column
         attr_reader :codec, :default_kind
 

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -241,13 +241,22 @@ module ActiveRecord
           result = do_system_execute("DESCRIBE TABLE `#{table_name}`", table_name)
           data = result['data']
 
-          return data unless data.empty?
+          raise ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'" if data.empty?
 
-          raise ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'"
+          data.map do |row|
+            Clickhouse::DescribedColumn.new(
+              name: row[0],
+              sql_type: row[1],
+              default_type: row[2],
+              default_expression: row[3],
+              comment: row[4],
+              codec: row[5],
+            )
+          end
         end
 
         def column_definitions(table_name)
-          table_structure(table_name).reject { |field| field[2].to_s.downcase == 'ephemeral' }
+          table_structure(table_name).reject(&:ephemeral?)
         end
 
         private
@@ -261,18 +270,17 @@ module ActiveRecord
         end
 
         def new_column_from_field(table_name, field, _definitions)
-          column_name, sql_type, default_type, default_expression = field
-          type_metadata = fetch_type_metadata(sql_type)
-          default_value = extract_value_from_default(default_expression, default_type)
-          default_function = extract_default_function(default_expression)
-          cast_type = lookup_cast_type(sql_type)
+          type_metadata = fetch_type_metadata(field.sql_type)
+          default_value = extract_value_from_default(field.default_expression, field.default_type)
+          default_function = extract_default_function(field.default_expression)
+          cast_type = lookup_cast_type(field.sql_type)
           default_value = cast_type.cast(default_value)
 
-          args = [column_name]
+          args = [field.name]
           args << cast_type if ::ActiveRecord::version >= Gem::Version.new('8.1')
-          args += [default_value, type_metadata, field[1].include?('Nullable'), default_function]
+          args += [default_value, type_metadata, field.sql_type.include?('Nullable'), default_function]
 
-          Clickhouse::Column.new(*args, codec: field[5].presence, default_kind: default_type)
+          Clickhouse::Column.new(*args, codec: field.codec.presence, default_kind: field.default_type)
         end
 
         def extract_value_from_default(default_expression, default_type)

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -245,7 +245,10 @@ module ActiveRecord
 
           raise ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'"
         end
-        alias column_definitions table_structure
+
+        def column_definitions(table_name)
+          table_structure(table_name).reject { |field| field[2].to_s.downcase == 'ephemeral' }
+        end
 
         private
 
@@ -269,7 +272,7 @@ module ActiveRecord
           args << cast_type if ::ActiveRecord::version >= Gem::Version.new('8.1')
           args += [default_value, type_metadata, field[1].include?('Nullable'), default_function]
 
-          Clickhouse::Column.new(*args, codec: field[5].presence)
+          Clickhouse::Column.new(*args, codec: field[5].presence, default_kind: default_type)
         end
 
         def extract_value_from_default(default_expression, default_type)

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -312,7 +312,7 @@ module ActiveRecord
         end
 
         pk = table_structure(table_name).first
-        return ['id'] if pk.present? && pk[0] == 'id'
+        return ['id'] if pk.present? && pk.name == 'id'
         []
       end
 
@@ -434,9 +434,9 @@ module ActiveRecord
       end
 
       def change_column_null(table_name, column_name, null, default = nil)
-        structure = table_structure(table_name).select{|v| v[0] == column_name.to_s}.first
+        structure = table_structure(table_name).find { |col| col.name == column_name.to_s }
         raise "Column #{column_name} not found in table #{table_name}" if structure.nil?
-        change_column table_name, column_name, structure[1].gsub(/(Nullable\()?(.*?)\)?/, '\2'), {null: null, default: default}.compact
+        change_column table_name, column_name, structure.sql_type.gsub(/(Nullable\()?(.*?)\)?/, '\2'), {null: null, default: default}.compact
       end
 
       def change_column_default(table_name, column_name, default)

--- a/spec/single/column_default_types_spec.rb
+++ b/spec/single/column_default_types_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Column default types', :migrations do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  before do
+    connection.execute('DROP TABLE IF EXISTS column_default_types_test')
+    connection.execute(<<~SQL.squish)
+      CREATE TABLE column_default_types_test (
+        id UInt64,
+        name String DEFAULT '',
+        computed String MATERIALIZED upper(name),
+        scratch UInt64 EPHEMERAL 0,
+        display String ALIAS lower(name)
+      ) ENGINE = MergeTree ORDER BY id
+    SQL
+  end
+
+  after do
+    connection.execute('DROP TABLE IF EXISTS column_default_types_test')
+  end
+
+  let!(:model) do
+    Class.new(ActiveRecord::Base) do
+      self.table_name = 'column_default_types_test'
+    end
+  end
+
+  describe 'Column#default_kind' do
+    it 'is default? for DEFAULT columns' do
+      col = model.columns_hash['name']
+      expect(col.default_kind).to be_default
+    end
+
+    it 'is materialized? for MATERIALIZED columns' do
+      col = model.columns_hash['computed']
+      expect(col.default_kind).to be_materialized
+    end
+
+    it 'is alias? for ALIAS columns' do
+      col = model.columns_hash['display']
+      expect(col.default_kind).to be_alias
+    end
+
+    it 'is none? for plain columns' do
+      col = model.columns_hash['id']
+      expect(col.default_kind).to be_none
+    end
+
+    it 'does not expose EPHEMERAL columns in columns_hash' do
+      expect(model.columns_hash).not_to have_key('scratch')
+    end
+  end
+
+  describe 'INSERT behavior' do
+    it 'creates a record successfully (excludes MATERIALIZED and ALIAS from INSERT)' do
+      expect {
+        model.create!(id: 1, name: 'hello')
+      }.to change { model.count }.by(1)
+    end
+
+    it 'excludes MATERIALIZED columns even when dirtied' do
+      record = model.new(id: 3, name: 'dirty')
+      record[:computed] = 'MANUAL'
+      expect { record.save! }.not_to raise_error
+    end
+
+    it 'excludes ALIAS columns even when dirtied' do
+      record = model.new(id: 4, name: 'dirty')
+      record[:display] = 'manual'
+      expect { record.save! }.not_to raise_error
+    end
+
+    it 'creates a record with insert_all' do
+      expect {
+        model.insert_all([{ id: 2, name: 'world' }])
+      }.to change { model.count }.by(1)
+    end
+  end
+
+  describe 'SELECT behavior' do
+    before { model.create!(id: 1, name: 'Hello') }
+
+    it 'SELECT * does not include MATERIALIZED or ALIAS columns' do
+      record = model.first
+      expect(record.attributes).to include('id', 'name')
+      expect(record.attributes).not_to include('computed', 'display')
+    end
+
+    it 'MATERIALIZED columns can be selected explicitly' do
+      record = model.select(:id, :computed).first
+      expect(record.computed).to eq('HELLO')
+    end
+
+    it 'ALIAS columns can be selected explicitly' do
+      record = model.select(:id, :display).first
+      expect(record.display).to eq('hello')
+    end
+  end
+
+  describe 'WHERE behavior' do
+    before { model.create!(id: 1, name: 'Hello') }
+
+    it 'can filter on MATERIALIZED columns' do
+      record = model.select(:id, :computed).where(computed: 'HELLO').first
+      expect(record).to be_present
+      expect(record.computed).to eq('HELLO')
+    end
+
+    it 'can filter on ALIAS columns' do
+      record = model.select(:id, :display).where(display: 'hello').first
+      expect(record).to be_present
+      expect(record.display).to eq('hello')
+    end
+  end
+end


### PR DESCRIPTION
Parse out different flavors of `DEFAULT` expressions in columns, so that the adapter is aware of `EPHEMERAL`, `MATERIALIZED`, and `ALIAS` semantics -- Which columns can never be inserted? Which columns can only be selected explicitly (not just with `*`)? Which columns can never be selected or used in `WHERE`?