### PR TITLE
Add a failing spec to showcase a bug in migration

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   clickhouse:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION}'
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-25.10}'
     container_name: 'clickhouse-activerecord-clickhouse-server'
     ports:
       - '18123:8123'

--- a/bin/test-single
+++ b/bin/test-single
@@ -3,5 +3,7 @@ set -euo pipefail
 
 export CLICKHOUSE_PORT="${CLICKHOUSE_PORT:-18123}"
 export CLICKHOUSE_DATABASE="${CLICKHOUSE_DATABASE:-default}"
+export CLICKHOUSE_USER="${CLICKHOUSE_USER:-test}"
+export CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-test}"
 
 exec bundle exec rspec spec/single --format progress "$@"

--- a/spec/fixtures/migrations/dsl_add_column/2_modify_some_table.rb
+++ b/spec/fixtures/migrations/dsl_add_column/2_modify_some_table.rb
@@ -3,6 +3,6 @@
 class ModifySomeTable < ActiveRecord::Migration[7.1]
   def up
     add_column :some, :new_column, :big_integer
+    add_column :some, :new_uint16, :integer, limit: 2, unsigned: true
   end
 end
-

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -348,13 +348,15 @@ RSpec.describe 'Migration', :migrations do
 
         current_schema = schema(model)
 
-        expect(current_schema.keys.count).to eq(3)
+        expect(current_schema.keys.count).to eq(4)
         expect(current_schema).to have_key('id')
         expect(current_schema).to have_key('date')
         expect(current_schema).to have_key('new_column')
+        expect(current_schema).to have_key('new_uint16')
         expect(current_schema['id'].sql_type).to eq('UInt32')
         expect(current_schema['date'].sql_type).to eq('Date')
         expect(current_schema['new_column'].sql_type).to eq('Nullable(UInt64)')
+        expect(current_schema['new_uint16'].sql_type).to eq('Nullable(UInt16)')
       end
     end
 


### PR DESCRIPTION
The `:limit` parameter of `add_column` is ignored when altering tables and adding column in a migration.

I don't know the internal of AR adapters very well (or at all) so I'm not sure how to fix this, but I assumed adding a failing spec was a good basis for discussing the issue.