### PR TITLE
Implement URL-based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,33 @@ default: &default
   keep_alive_timeout: 300
 ```
 
+### URL-based configuration
+
+You can configure the adapter with a single `url` key instead of individual fields:
+
+```yml
+default: &default
+  adapter: clickhouse
+  url: clickhouse://username:password@localhost:8123/database
+```
+
+Optional settings can be passed as query parameters:
+
+```
+clickhouse://username:password@localhost:8123/database?ssl=true&http_auth=basic&read_timeout=300&write_timeout=300&keep_alive_timeout=300&debug=false&cluster_name=my_cluster
+```
+
+Supported query parameters: `ssl` (true/false), `debug` (true/false), `http_auth` (query_params/basic/x_clickhouse_headers), `read_timeout`, `write_timeout`, `keep_alive_timeout` (integers), `cluster_name`, `sslca`.
+
+If both a `url` and explicit keys are provided, the explicit keys take precedence:
+
+```yml
+default: &default
+  adapter: clickhouse
+  url: clickhouse://username:password@localhost:8123/database
+  host: production.db.internal  # overrides the host from the URL
+```
+
 Alternatively if you wish to pass a custom `Net::HTTP` transport (or any other
 object which supports a `.post()` function with the same parameters as
 `Net::HTTP`'s), you can do this directly instead of specifying

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -30,7 +30,7 @@ module ActiveRecord
         config = config.symbolize_keys
 
         if config[:url]
-          url_config = parse_clickhouse_url(config.delete(:url))
+          url_config = ConnectionAdapters::ClickhouseAdapter.parse_clickhouse_url(config.delete(:url))
           config = url_config.merge(config)
         end
 
@@ -46,39 +46,6 @@ module ActiveRecord
         end
 
         ConnectionAdapters::ClickhouseAdapter.new(config)
-      end
-
-      private
-
-      def parse_clickhouse_url(url)
-        uri = URI.parse(url)
-        config = {}
-
-        config[:host]     = uri.host                                    if uri.host
-        config[:port]     = uri.port                                    if uri.port
-        config[:username] = URI.decode_www_form_component(uri.user)     if uri.user
-        config[:password] = URI.decode_www_form_component(uri.password) if uri.password
-
-        if uri.path && uri.path.length > 1
-          config[:database] = uri.path.delete_prefix('/')
-        end
-
-        if uri.query
-          URI.decode_www_form(uri.query).each do |key, value|
-            case key
-            when 'ssl'                then config[:ssl]                = (value == 'true')
-            when 'debug'              then config[:debug]              = (value == 'true')
-            when 'read_timeout'       then config[:read_timeout]       = value.to_i
-            when 'write_timeout'      then config[:write_timeout]      = value.to_i
-            when 'keep_alive_timeout' then config[:keep_alive_timeout] = value.to_i
-            when 'http_auth'          then config[:http_auth]          = value
-            when 'cluster_name'       then config[:cluster_name]       = value
-            when 'sslca'              then config[:sslca]              = value
-            end
-          end
-        end
-
-        config
       end
     end
   end
@@ -167,6 +134,11 @@ module ActiveRecord
 
       # Initializes and connects a Clickhouse adapter.
       def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_options = nil, deprecated_config = nil)
+        if config_or_deprecated_connection.is_a?(Hash) && config_or_deprecated_connection[:url]
+          config_or_deprecated_connection = config_or_deprecated_connection.dup
+          url_config = self.class.parse_clickhouse_url(config_or_deprecated_connection.delete(:url))
+          config_or_deprecated_connection = url_config.merge(config_or_deprecated_connection)
+        end
         super
         if @config[:connection]
           connection = {
@@ -237,6 +209,37 @@ module ActiveRecord
       end
 
       class << self
+        def parse_clickhouse_url(url)
+          uri = URI.parse(url)
+          config = {}
+
+          config[:host]     = uri.host                                    if uri.host
+          config[:port]     = uri.port                                    if uri.port
+          config[:username] = URI.decode_www_form_component(uri.user)     if uri.user
+          config[:password] = URI.decode_www_form_component(uri.password) if uri.password
+
+          if uri.path && uri.path.length > 1
+            config[:database] = uri.path.delete_prefix('/')
+          end
+
+          if uri.query
+            URI.decode_www_form(uri.query).each do |key, value|
+              case key
+              when 'ssl'                then config[:ssl]                = (value == 'true')
+              when 'debug'              then config[:debug]              = (value == 'true')
+              when 'read_timeout'       then config[:read_timeout]       = value.to_i
+              when 'write_timeout'      then config[:write_timeout]      = value.to_i
+              when 'keep_alive_timeout' then config[:keep_alive_timeout] = value.to_i
+              when 'http_auth'          then config[:http_auth]          = value
+              when 'cluster_name'       then config[:cluster_name]       = value
+              when 'sslca'              then config[:sslca]              = value
+              end
+            end
+          end
+
+          config
+        end
+
         def extract_limit(sql_type) # :nodoc:
           case sql_type
             when /(Nullable)?\(?String\)?/

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -20,6 +20,7 @@ require 'active_record/connection_adapters/clickhouse/statement'
 require 'active_record/connection_adapters/clickhouse/table_definition'
 require 'net/http'
 require 'openssl'
+require 'uri'
 
 module ActiveRecord
   class Base
@@ -27,6 +28,11 @@ module ActiveRecord
       # Establishes a connection to the database that's used by all Active Record objects
       def clickhouse_connection(config)
         config = config.symbolize_keys
+
+        if config[:url]
+          url_config = parse_clickhouse_url(config.delete(:url))
+          config = url_config.merge(config)
+        end
 
         unless config.key?(:database)
           raise ArgumentError, 'No database specified. Missing argument: database.'
@@ -40,6 +46,39 @@ module ActiveRecord
         end
 
         ConnectionAdapters::ClickhouseAdapter.new(config)
+      end
+
+      private
+
+      def parse_clickhouse_url(url)
+        uri = URI.parse(url)
+        config = {}
+
+        config[:host]     = uri.host                                    if uri.host
+        config[:port]     = uri.port                                    if uri.port
+        config[:username] = URI.decode_www_form_component(uri.user)     if uri.user
+        config[:password] = URI.decode_www_form_component(uri.password) if uri.password
+
+        if uri.path && uri.path.length > 1
+          config[:database] = uri.path.delete_prefix('/')
+        end
+
+        if uri.query
+          URI.decode_www_form(uri.query).each do |key, value|
+            case key
+            when 'ssl'                then config[:ssl]                = (value == 'true')
+            when 'debug'              then config[:debug]              = (value == 'true')
+            when 'read_timeout'       then config[:read_timeout]       = value.to_i
+            when 'write_timeout'      then config[:write_timeout]      = value.to_i
+            when 'keep_alive_timeout' then config[:keep_alive_timeout] = value.to_i
+            when 'http_auth'          then config[:http_auth]          = value
+            when 'cluster_name'       then config[:cluster_name]       = value
+            when 'sslca'              then config[:sslca]              = value
+            end
+          end
+        end
+
+        config
       end
     end
   end

--- a/spec/single/url_config_spec.rb
+++ b/spec/single/url_config_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+RSpec.describe 'URL-based configuration' do
+  let(:http_connection) { instance_double(Net::HTTP) }
+  let(:response) { instance_double(Net::HTTPResponse, code: '200', body: '') }
+
+  before do
+    allow(Net::HTTP).to receive(:start).and_return(http_connection)
+    allow(http_connection).to receive(:keep_alive_timeout=)
+    allow(http_connection).to receive(:started?).and_return(true)
+    allow(http_connection).to receive(:post).and_return(response)
+  end
+
+  def net_http_start_args
+    args = nil
+    allow(Net::HTTP).to receive(:start) do |*a, **kw, &block|
+      args = { args: a, kwargs: kw }
+      block.call(http_connection) if block
+      http_connection
+    end
+    ActiveRecord::Base.clickhouse_connection(config)
+    args
+  end
+
+  context 'basic URL' do
+    let(:config) { { url: 'clickhouse://app_user:secret@db.example.com:9000/mydb' } }
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'sets host from URL' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:host]).to eq('db.example.com')
+    end
+
+    it 'sets port from URL' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:port]).to eq(9000)
+    end
+
+    it 'sets username from URL' do
+      expect(adapter.instance_variable_get(:@connection_config)[:user]).to eq('app_user')
+    end
+
+    it 'sets password from URL' do
+      expect(adapter.instance_variable_get(:@connection_config)[:password]).to eq('secret')
+    end
+
+    it 'sets database from URL path' do
+      expect(adapter.instance_variable_get(:@connection_config)[:database]).to eq('mydb')
+    end
+  end
+
+  context 'URL with special characters in credentials' do
+    let(:config) { { url: 'clickhouse://us%40er:p%40ss%3Aword@localhost:8123/testdb' } }
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'decodes username' do
+      expect(adapter.instance_variable_get(:@connection_config)[:user]).to eq('us@er')
+    end
+
+    it 'decodes password' do
+      expect(adapter.instance_variable_get(:@connection_config)[:password]).to eq('p@ss:word')
+    end
+  end
+
+  context 'URL with query parameters' do
+    let(:config) { { url: 'clickhouse://user:pass@localhost:8123/db?ssl=true&debug=true&read_timeout=120&write_timeout=90&keep_alive_timeout=30&http_auth=basic&cluster_name=mycluster' } }
+
+    before do
+      allow(http_connection).to receive(:read_timeout=)
+      allow(http_connection).to receive(:write_timeout=)
+    end
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'sets ssl from query params' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:ssl]).to eq(true)
+    end
+
+    it 'sets debug from query params' do
+      expect(adapter.instance_variable_get(:@debug)).to eq(true)
+    end
+
+    it 'sets read_timeout from query params' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:read_timeout]).to eq(120)
+    end
+
+    it 'sets write_timeout from query params' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:write_timeout]).to eq(90)
+    end
+
+    it 'sets keep_alive_timeout from query params' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:keep_alive_timeout]).to eq(30)
+    end
+
+    it 'sets http_auth from query params' do
+      expect(adapter.instance_variable_get(:@http_auth)).to eq(:basic)
+    end
+  end
+
+  context 'explicit config keys override URL values' do
+    let(:config) do
+      {
+        url: 'clickhouse://url_user:url_pass@url_host:9000/url_db',
+        host: 'override_host',
+        database: 'override_db',
+        username: 'override_user'
+      }
+    end
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'uses explicit host over URL host' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:host]).to eq('override_host')
+    end
+
+    it 'uses explicit database over URL database' do
+      expect(adapter.instance_variable_get(:@connection_config)[:database]).to eq('override_db')
+    end
+
+    it 'uses explicit username over URL username' do
+      expect(adapter.instance_variable_get(:@connection_config)[:user]).to eq('override_user')
+    end
+
+    it 'keeps URL password when not overridden' do
+      expect(adapter.instance_variable_get(:@connection_config)[:password]).to eq('url_pass')
+    end
+  end
+
+  context 'URL without port' do
+    let(:config) { { url: 'clickhouse://localhost/mydb' } }
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'uses default port 8123' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:port]).to eq(8123)
+    end
+  end
+
+  context 'URL without database' do
+    let(:config) { { url: 'clickhouse://localhost:8123' } }
+
+    it 'raises ArgumentError about missing database' do
+      expect { ActiveRecord::Base.clickhouse_connection(config) }
+        .to raise_error(ArgumentError, /No database specified/)
+    end
+  end
+
+  context 'URL with invalid http_auth' do
+    let(:config) { { url: 'clickhouse://localhost:8123/db?http_auth=invalid_mode' } }
+
+    it 'raises ArgumentError about unknown http_auth mode' do
+      expect { ActiveRecord::Base.clickhouse_connection(config) }
+        .to raise_error(ArgumentError, /Unknown :http_auth mode/)
+    end
+  end
+
+  context 'backward compatibility without url key' do
+    let(:config) do
+      {
+        adapter: 'clickhouse',
+        host: 'localhost',
+        port: 8123,
+        database: 'test_db',
+        username: 'user',
+        password: 'pass'
+      }
+    end
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    it 'still works with explicit hash config' do
+      expect(adapter.instance_variable_get(:@connection_parameters)[:host]).to eq('localhost')
+      expect(adapter.instance_variable_get(:@connection_config)[:database]).to eq('test_db')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements https://github.com/PNixx/clickhouse-activerecord/issues/200

- Allows configuring the adapter with a single `url` key (e.g. `clickhouse://user:pass@host:8123/db`) instead of specifying every connection field individually
- Supports optional settings as query parameters: `ssl`, `debug`, `http_auth`, `read_timeout`, `write_timeout`, `keep_alive_timeout`, `cluster_name`, `sslca`
- Explicit config keys take precedence over URL-parsed values, so partial overrides work cleanly