### PR TITLE
Fix `@response_format` thread race in `with_response_format`

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -37,14 +37,14 @@ module ActiveRecord
         #   end
         #   # sends and executes "SELECT * FROM table"
         def with_response_format(format)
-          prev_format = @response_format
-          @response_format = format
+          stack = response_format_stack
+          stack.push(format)
           yield
         ensure
-          @response_format = prev_format
+          stack.pop
         end
 
-        def execute(sql, name = nil, format: @response_format, settings: {})
+        def execute(sql, name = nil, format: response_format, settings: {})
           with_response_format(format) do
             log(sql, [adapter_name, name].compact.join(' ')) do
               raw_execute(sql, settings: settings)
@@ -60,10 +60,10 @@ module ActiveRecord
 
         # Execute an SQL query and save the result to a file in stream mode
         # @return [Tempfile]
-        def execute_to_file(sql, name = nil, format: @response_format, settings: {})
+        def execute_to_file(sql, name = nil, format: response_format, settings: {})
           with_response_format(format) do
             log(sql, [adapter_name, 'Stream', name].compact.join(' ')) do
-              statement = Statement.new(sql, format: @response_format)
+              statement = Statement.new(sql, format: response_format)
               result = nil
               @lock.synchronize do
                 req = Net::HTTP::Post.new("/?#{settings_params(settings)}", build_request_headers)
@@ -113,7 +113,7 @@ module ActiveRecord
         # @link https://clickhouse.com/docs/en/sql-reference/statements/delete
         def exec_delete(sql, name = nil, _binds = [])
           log(sql, "#{adapter_name} #{name}") do
-            statement = Statement.new(sql, format: @response_format)
+            statement = Statement.new(sql, format: response_format)
             res = request(statement)
             begin
               data = JSON.parse(res.header['x-clickhouse-summary'])
@@ -302,7 +302,7 @@ module ActiveRecord
         end
 
         def raw_execute(sql, settings: {}, except_params: [])
-          statement = Statement.new(sql, format: @response_format)
+          statement = Statement.new(sql, format: response_format)
           response = request(statement, settings: settings, except_params: except_params)
           statement.processed_response(response)
         end
@@ -323,6 +323,19 @@ module ActiveRecord
         def log_with_debug(sql, name = nil)
           return yield unless @debug
           log(sql, "#{name} (system)") { yield }
+        end
+
+        # The response format that should be applied to the next request.
+        # Reads the per-thread override pushed by `with_response_format`, falling
+        # back to the adapter-level default when no override is in scope.
+        def response_format
+          stack = response_format_stack
+          stack.empty? ? @default_response_format : stack.last
+        end
+
+        def response_format_stack
+          key = (@response_format_stack_key ||= :"clickhouse_response_format_stack_#{object_id}")
+          Thread.current[key] ||= []
         end
 
         def settings_params(settings = {}, except: [])

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -149,7 +149,7 @@ module ActiveRecord
 
         @connection_config = { user: @config[:username], password: @config[:password], database: @config[:database] }.compact
         @debug = @config[:debug] || false
-        @response_format = @config[:format] || DEFAULT_RESPONSE_FORMAT
+        @default_response_format = @config[:format] || DEFAULT_RESPONSE_FORMAT
         @http_auth = @config[:http_auth]&.to_sym
 
         @prepared_statements = false

--- a/spec/single/response_format_thread_safety_spec.rb
+++ b/spec/single/response_format_thread_safety_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Regression coverage for the @response_format thread-safety race.
+#
+# `with_response_format` mutates an instance variable on the adapter to scope
+# the response format for the duration of a block. When the same adapter is
+# shared across threads — as happens in Capybara system specs where the test
+# thread and the Puma server thread both check out the same connection — one
+# thread's block can leak its format into another thread's `execute` call,
+# returning the raw response body instead of a parsed Hash.
+RSpec.describe 'ActiveRecord::ConnectionAdapters::Clickhouse::SchemaStatements response format thread safety' do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:default_format) { ActiveRecord::ConnectionAdapters::ClickhouseAdapter::DEFAULT_RESPONSE_FORMAT }
+
+  before do
+    connection.execute('CREATE TABLE response_format_thread_test (id UInt64) ENGINE = MergeTree ORDER BY id')
+  end
+
+  after do
+    connection.execute('DROP TABLE IF EXISTS response_format_thread_test')
+  end
+
+  it '#execute on one thread is not affected by with_response_format(nil) on another thread' do
+    inside_block = Queue.new
+    release = Queue.new
+
+    holder = Thread.new do
+      connection.with_response_format(nil) do
+        inside_block << true
+        release.pop
+      end
+    end
+
+    inside_block.pop
+
+    begin
+      result = connection.execute('SELECT count() AS c FROM response_format_thread_test')
+
+      expect(result).to be_a(Hash), "expected parsed Hash from default format, got #{result.class}: #{result.inspect[0..200]}"
+      expect(result['data']).to be_a(Array)
+    ensure
+      release << true
+      holder.join
+    end
+  end
+
+  it 'with_response_format nests correctly within a single thread' do
+    expect(connection.execute('SELECT 1 AS x')).to be_a(Hash)
+
+    connection.with_response_format(nil) do
+      expect(connection.execute('SELECT 1 AS x')).to be_a(String)
+
+      connection.with_response_format('JSONCompact') do
+        expect(connection.execute('SELECT 1 AS x')).to be_a(Hash)
+      end
+
+      expect(connection.execute('SELECT 1 AS x')).to be_a(String)
+    end
+
+    expect(connection.execute('SELECT 1 AS x')).to be_a(Hash)
+  end
+end


### PR DESCRIPTION
## Summary

`with_response_format` mutates a shared `@response_format` instance variable on the adapter. When the same adapter is checked out across threads — for example, in Capybara system specs where the test thread and the Puma server thread share a connection while `use_transactional_fixtures` is on — one thread's override leaks into another thread's request.

## How it manifests

`exec_insert` and `exec_insert_all` wrap `execute` with `with_response_format(nil) { ... }` to suppress the `FORMAT` clause for INSERT statements. While that wrapper is active, any other thread that calls `execute(sql)` evaluates the `format:` keyword default as `@response_format`, and gets back `nil`. The SELECT is sent without a `FORMAT` clause, the server replies in `TabSeparated`, and `ResponseProcessor#format_body_response` falls through to returning the raw String body. `internal_exec_query` then blows up on `result['meta'].map`, which surfaces as `Response: undefined method 'map' for nil`.

The race is invisible in single-threaded specs but reproduces deterministically once an INSERT path and a SELECT path overlap on the same adapter from two threads (e.g. a Rails system spec where the test thread issues a SELECT while the Capybara/Puma worker is processing an unrelated INSERT against the same connection).

## Fix

Replace the shared instance variable with a per-thread, per-adapter stack stored on `Thread.current`, keyed by the adapter's `object_id`. `with_response_format` pushes/pops a frame; a new private `response_format` reader returns the top of the stack, falling back to a renamed `@default_response_format` ivar when no override is in scope.

Public API is unchanged — `with_response_format`, `execute(..., format:)`, and `execute_to_file(..., format:)` all behave the same to callers. The rename of the inner ivar (`@response_format` → `@default_response_format`) is intentional: it makes any future code that re-introduces shared mutable format state surface as a merge conflict rather than silently re-introducing the race.

## Test coverage

Adds `spec/single/response_format_thread_safety_spec.rb` with two cases:

- **Cross-thread isolation**: while thread A holds `with_response_format(nil)`, thread B's `execute(sql)` must return a parsed `Hash` rather than the raw `String` body. Fails deterministically against the previous implementation; passes after the fix.
- **Single-thread nesting**: the existing contract that nested `with_response_format` blocks compose correctly within one thread.

Full single-server suite remains green (147 examples).
