### PR TITLE
Honor unsigned: false on integer columns without a limit

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/table_definition.rb
+++ b/lib/active_record/connection_adapters/clickhouse/table_definition.rb
@@ -41,7 +41,7 @@ module ActiveRecord
           unsigned = options[:unsigned]
           unsigned = true if unsigned.nil?
 
-          kind = :uint32 # default
+          kind = unsigned ? :uint32 : :int32 # default
 
           if options[:limit]
             if unsigned

--- a/spec/fixtures/migrations/dsl_table_with_integer_creation/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_table_with_integer_creation/1_create_some_table.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateSomeTable < ActiveRecord::Migration[7.1]
+  def up
+    create_table :some, id: false do |t|
+      t.integer :default_int
+      t.integer :signed_no_limit, unsigned: false, null: false, default: -1
+      t.integer :signed_small, unsigned: false, limit: 1, null: false, default: -1
+      t.integer :signed_int32, unsigned: false, limit: 4, null: false, default: -1
+      t.integer :signed_int64, unsigned: false, limit: 8, null: false, default: -1
+      t.integer :unsigned_tiny, unsigned: true, limit: 1, null: false, default: 0
+    end
+  end
+end

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -96,6 +96,26 @@ RSpec.describe 'Migration', :migrations do
         end
 
         context 'types' do
+          context 'integer' do
+            let(:directory) { 'dsl_table_with_integer_creation' }
+            it 'honors unsigned: false even when limit is omitted' do
+              subject
+
+              current_schema = schema(model)
+
+              expect(current_schema['default_int'].sql_type).to eq('Nullable(UInt32)')
+              expect(current_schema['signed_no_limit'].sql_type).to eq('Int32')
+              expect(current_schema['signed_no_limit'].default).to eq(-1)
+              expect(current_schema['signed_small'].sql_type).to eq('Int8')
+              expect(current_schema['signed_small'].default).to eq(-1)
+              expect(current_schema['signed_int32'].sql_type).to eq('Int32')
+              expect(current_schema['signed_int32'].default).to eq(-1)
+              expect(current_schema['signed_int64'].sql_type).to eq('Int64')
+              expect(current_schema['signed_int64'].default).to eq(-1)
+              expect(current_schema['unsigned_tiny'].sql_type).to eq('UInt8')
+            end
+          end
+
           context 'decimal' do
             let(:directory) { 'dsl_table_with_decimal_creation' }
             it 'creates a table with valid scale and precision' do


### PR DESCRIPTION
Fix integer columns ignoring unsigned: false when limit is omitted

t.integer with unsigned: false but no :limit was still being created as
UInt32 because the default `kind` was hardcoded. Setting a negative
default like -1 then raised ActiveModel::RangeError when loading the
schema.

Default `kind` now reflects the unsigned flag: :int32 when unsigned is
false, :uint32 otherwise.