### PR TITLE
#rails81_change_column fixed change_column, added hide_creds for mysql, tests added

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -302,9 +302,44 @@ module ActiveRecord
         end
 
         def raw_execute(sql, settings: {}, except_params: [])
+          return raw_execute_with_retry(sql, settings: {}, except_params: []) if @config&.fetch(:request_retries_on_fail)
+
           statement = Statement.new(sql, format: @response_format)
           response = request(statement, settings: settings, except_params: except_params)
           statement.processed_response(response)
+        end
+
+        def raw_execute_with_retry(sql, settings: {}, except_params: [])
+          resolved_sql = resolve_hidden_credentials(sql)
+          retries_count = (@config || {}).fetch(:request_retries_on_fail, 1).to_i
+          retries_count = 1 unless retries_count&.positive?
+          result = nil
+          retries_count.times do |retry_num|
+            begin
+              statement = Statement.new(resolved_sql, format: @response_format)
+              response = request(statement, settings: settings, except_params: except_params)
+              result = statement.processed_response(response)
+              break
+            rescue ActiveRecord::ConnectionTimeoutError, ActiveRecord::LockWaitTimeout => e
+              raise(e) unless (retry_num + 1) < retries_count
+              sleep(0.1 * (retry_num + 1))
+            end
+          end
+          result
+        end
+
+        MYSQL_ENGINE_RE = /MySQL\('[^']*'\s*,\s*'[^']*'\s*,\s*'[^']*'\s*,\s*'[^']*'\s*,\s*'[^']*'\)/i.freeze
+
+        def resolve_hidden_credentials(sql)
+          return sql unless sql.include?('[HIDDEN]')
+          sql.gsub(MYSQL_ENGINE_RE) do |match|
+            table_name = match.match(/MySQL\('([^']*)'\s*,\s*'([^']*)'\s*,\s*'([^']*)'\s*,\s*'([^']*)'\s*,\s*'([^']*)'\)/i)[3]
+            if ClickhouseActiverecord.mysql_credential_resolver
+              ClickhouseActiverecord.mysql_credential_resolver.call(table_name)
+            else
+              match
+            end
+          end
         end
 
         # Make HTTP request to ClickHouse server
@@ -383,7 +418,7 @@ module ActiveRecord
 
         # @see https://clickhouse.com/docs/sql-reference/statements/truncate
         # Additionally add 'Dictionary' because it is returned from 'show tables'.
-        TRUNCATE_UNSUPPORTED_ENGINES = %w[View File URL Buffer Null Dictionary].freeze
+        TRUNCATE_UNSUPPORTED_ENGINES = %w[View File URL Buffer Null Dictionary MySQL].freeze
 
         def build_truncate_statements(table_names)
           engines = table_engines(table_names)

--- a/lib/active_record/connection_adapters/clickhouse/table_definition.rb
+++ b/lib/active_record/connection_adapters/clickhouse/table_definition.rb
@@ -101,8 +101,19 @@ module ActiveRecord
 
         private
 
+        def create_column_definition(name, type, options)
+          unless options[:_skip_validate_options]
+            options.except(:_uses_legacy_reference_index_name, :_skip_validate_options).assert_valid_keys(valid_column_definition_options)
+          end
+
+          sql_type = @conn.type_to_sql(type, **options)
+          cast_type = @conn.lookup_cast_type(sql_type)
+
+          ColumnDefinition.new(name, type, options, sql_type, cast_type)
+        end
+
         def valid_column_definition_options
-          super + [:array, :low_cardinality, :fixed_string, :value, :type, :map, :codec, :unsigned]
+          super + [:array, :low_cardinality, :fixed_string, :value, :type, :map, :codec, :unsigned, :first, :after]
         end
       end
 

--- a/lib/clickhouse-activerecord.rb
+++ b/lib/clickhouse-activerecord.rb
@@ -20,6 +20,10 @@ if defined?(Rails::Railtie)
 end
 
 module ClickhouseActiverecord
+  class << self
+    attr_accessor :mysql_credential_resolver
+  end
+
   def self.load
     ActiveRecord::InternalMetadata.prepend(CoreExtensions::ActiveRecord::InternalMetadata)
     ActiveRecord::Migration::CommandRecorder.include(CoreExtensions::ActiveRecord::Migration::CommandRecorder)

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -1,6 +1,8 @@
 module ClickhouseActiverecord
   class SchemaDumper < ::ActiveRecord::ConnectionAdapters::SchemaDumper
 
+    MYSQL_ENGINE_TABLE_CONNECTION_REGEX = /MySQL\('[^']*'\s*,\s*'[^']*'\s*,\s*'[^']*'\s*,\s*'[^']*'\s*,\s*'[^']*'\)/i.freeze
+
     attr_accessor :simple
 
     class << self
@@ -22,10 +24,10 @@ module ClickhouseActiverecord
 
       view_tables = @connection.views.sort
       materialized_view_tables = @connection.materialized_views.sort
-      sorted_tables = @connection.tables.sort - view_tables - materialized_view_tables
+      sorted_tables = @connection.tables.sort - view_tables - materialized_view_tables - dictionary_names
 
       (sorted_tables + view_tables + materialized_view_tables).each do |table_name|
-        table(table_name, stream) unless ignored?(table_name)
+        table(table_name, stream) unless ignored?(table_name) || dictionary_names.include?(table_name)
       end
     end
 
@@ -36,6 +38,10 @@ module ClickhouseActiverecord
         unless simple
           stream.puts "  # TABLE: #{table}"
           sql = @connection.show_create_table(table)
+          sql.gsub!(MYSQL_ENGINE_TABLE_CONNECTION_REGEX) do |match|
+            table_name = match.match(/MySQL\('([^']*)'\s*,\s*'([^']*)'\s*,\s*'([^']*)'\s*,\s*'([^']*)'\s*,\s*'([^']*)'\)/i)[3]
+            "MySQL('[HIDDEN]', '[HIDDEN]', '#{table_name}', '[HIDDEN]', '[HIDDEN]')"
+          end
           stream.puts "  # SQL: #{sql.gsub(/ENGINE = Replicated(.*?)\('[^']+',\s*'[^']+',?\s?([^\)]*)?\)/, "ENGINE = \\1(\\2)")}" if sql
           # super(table.gsub(/^\.inner\./, ''), stream)
 
@@ -143,7 +149,12 @@ module ClickhouseActiverecord
       if options && options[:options]
         options[:options].gsub!(/^Replicated(.*?)\('[^']+',\s*'[^']+',?\s?([^\)]*)?\)/, "\\1(\\2)")
       end
-      super
+      result = super(options)
+      result.gsub!(MYSQL_ENGINE_TABLE_CONNECTION_REGEX) do |match|
+        table_name = match.match(/MySQL\('([^']*)'\s*,\s*'([^']*)'\s*,\s*'([^']*)'\s*,\s*'([^']*)'\s*,\s*'([^']*)'\)/i)[3]
+        "MySQL('[HIDDEN]', '[HIDDEN]', '#{table_name}', '[HIDDEN]', '[HIDDEN]')"
+      end
+      result
     end
 
     def format_colspec(colspec)
@@ -203,6 +214,13 @@ module ClickhouseActiverecord
       ]
       index_parts << "granularity: #{idx['granularity']}" if idx['granularity']
       index_parts
+    end
+
+    def dictionary_names
+      @dictionary_names ||= begin
+        res = @connection.do_system_execute("SELECT name FROM system.tables WHERE engine = 'Dictionary' AND database = currentDatabase()")
+        (res['data'] || []).flatten
+      end
     end
   end
 end

--- a/spec/single/column_options_spec.rb
+++ b/spec/single/column_options_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe 'ColumnOptions' do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  describe '#valid_column_definition_options' do
+    it 'includes :first and :after' do
+      td = ActiveRecord::ConnectionAdapters::Clickhouse::TableDefinition.new(connection, :test)
+      options = td.send(:valid_column_definition_options)
+      expect(options).to include(:first, :after)
+    end
+
+    it 'includes all clickhouse-specific options' do
+      td = ActiveRecord::ConnectionAdapters::Clickhouse::TableDefinition.new(connection, :test)
+      options = td.send(:valid_column_definition_options)
+      expect(options).to include(:array, :low_cardinality, :fixed_string, :value, :type, :map, :codec, :unsigned)
+    end
+  end
+
+  describe '#create_column_definition' do
+    let(:td) { ActiveRecord::ConnectionAdapters::Clickhouse::TableDefinition.new(connection, :test) }
+
+    it 'creates a ColumnDefinition with sql_type and cast_type' do
+      cd = td.send(:create_column_definition, :name, :string, null: false)
+      expect(cd).to be_a(ActiveRecord::ConnectionAdapters::ColumnDefinition)
+      expect(cd.name).to eq(:name)
+      expect(cd.type).to eq(:string)
+      expect(cd.sql_type).to be_a(String)
+      expect(cd.sql_type).to eq('String')
+    end
+
+    it 'accepts :first and :after in options' do
+      expect {
+        td.send(:create_column_definition, :col, :integer, first: true)
+      }.not_to raise_error
+
+      expect {
+        td.send(:create_column_definition, :col, :integer, after: :other_col)
+      }.not_to raise_error
+    end
+
+    it 'accepts clickhouse-specific options' do
+      expect {
+        td.send(:create_column_definition, :col, :string, low_cardinality: true)
+      }.not_to raise_error
+
+      expect {
+        td.send(:create_column_definition, :col, :string, codec: 'LZ4')
+      }.not_to raise_error
+
+      expect {
+        td.send(:create_column_definition, :col, :integer, unsigned: false)
+      }.not_to raise_error
+    end
+  end
+
+  describe '#integer with :first and :after' do
+    it 'works with migration context' do
+      expect {
+        connection.create_table(:test_positions, id: false, force: true) do |t|
+          t.integer :id, null: false
+          t.string :name, null: false
+          t.integer :position, first: true
+        end
+      }.not_to raise_error
+
+      expect(connection.tables).to include('test_positions')
+    end
+
+    after do
+      connection.drop_table(:test_positions) rescue nil
+    end
+  end
+end

--- a/spec/single/hide_credentials_spec.rb
+++ b/spec/single/hide_credentials_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+RSpec.describe 'HideCredentials' do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  describe '#resolve_hidden_credentials' do
+    before do
+      @original_resolver = ClickhouseActiverecord.mysql_credential_resolver
+      ClickhouseActiverecord.mysql_credential_resolver = ->(table_name) {
+        "MySQL('host:3306','test_db','#{table_name}','user','pass')"
+      }
+    end
+
+    after do
+      ClickhouseActiverecord.mysql_credential_resolver = @original_resolver
+    end
+
+    it 'replaces [HIDDEN] with actual credentials via resolver' do
+      sql = "ENGINE = MySQL('[HIDDEN]', '[HIDDEN]', 'examples', '[HIDDEN]', '[HIDDEN]')"
+      result = connection.send(:resolve_hidden_credentials, sql)
+      expect(result).to eq("ENGINE = MySQL('host:3306','test_db','examples','user','pass')")
+    end
+
+    it 'returns sql unchanged if no [HIDDEN]' do
+      sql = "CREATE TABLE test (id UInt64) ENGINE = MergeTree ORDER BY id"
+      result = connection.send(:resolve_hidden_credentials, sql)
+      expect(result).to eq(sql)
+    end
+
+    it 'works without a resolver set' do
+      ClickhouseActiverecord.mysql_credential_resolver = nil
+      sql = "ENGINE = MySQL('[HIDDEN]', '[HIDDEN]', 'examples', '[HIDDEN]', '[HIDDEN]')"
+      result = connection.send(:resolve_hidden_credentials, sql)
+      expect(result).to eq(sql)
+    end
+
+    it 'passes the correct table_name to the resolver' do
+      passed_tables = []
+      ClickhouseActiverecord.mysql_credential_resolver = ->(table_name) {
+        passed_tables << table_name
+        "MySQL('h:1','db','#{table_name}','u','p')"
+      }
+      connection.send(:resolve_hidden_credentials,
+        "ENGINE = MySQL('[HIDDEN]', '[HIDDEN]', 'issues', '[HIDDEN]', '[HIDDEN]')")
+      expect(passed_tables).to eq(['issues'])
+    end
+
+    it 'handles multiple MySQL engine references' do
+      sql = "ENGINE = MySQL('[HIDDEN]','[HIDDEN]','t1','[HIDDEN]','[HIDDEN]'), " \
+            "ENGINE = MySQL('[HIDDEN]','[HIDDEN]','t2','[HIDDEN]','[HIDDEN]')"
+      result = connection.send(:resolve_hidden_credentials, sql)
+      expect(result).to include("MySQL('host:3306','test_db','t1','user','pass')")
+      expect(result).to include("MySQL('host:3306','test_db','t2','user','pass')")
+    end
+  end
+
+  describe '#raw_execute resolves hidden credentials' do
+    around do |example|
+      ClickhouseActiverecord.mysql_credential_resolver = ->(table_name) {
+        "MySQL('host:3306','test_db','#{table_name}','user','pass')"
+      }
+      example.run
+      ClickhouseActiverecord.mysql_credential_resolver = nil
+    end
+
+    it 'calls resolve_hidden_credentials before executing sql' do
+      expect(connection).to receive(:resolve_hidden_credentials).with("SELECT 1").and_call_original
+      connection.execute("SELECT 1")
+    end
+  end
+
+  describe 'SchemaDumper#format_options' do
+    let(:dumper) { ClickhouseActiverecord::SchemaDumper.new(connection) }
+
+    it 'replaces MySQL credentials with [HIDDEN]' do
+      options = { options: "MySQL('host:3306','test_db','examples','user','pass') SETTINGS connection_pool_size=8" }
+      result = dumper.send(:format_options, options)
+      expect(result).to include("MySQL('[HIDDEN]', '[HIDDEN]', 'examples', '[HIDDEN]', '[HIDDEN]')")
+      expect(result).not_to include('host:3306')
+      expect(result).not_to include('test_db')
+      expect(result).not_to include('user')
+      expect(result).not_to include('pass')
+    end
+
+    it 'still handles Replicated engine URLs' do
+      options = { options: "ReplicatedMergeTree('/clickhouse/tables/1/test','{replica}') PARTITION BY toDate(date) ORDER BY id" }
+      result = dumper.send(:format_options, options)
+      expect(result).to include("MergeTree")
+      expect(result).not_to include("ReplicatedMergeTree")
+    end
+
+    it 'handles both Replicated and MySQL in same options' do
+      options = { options: "ReplicatedMergeTree('/clickhouse/tables/1/test','{replica}') ORDER BY id" }
+      options[:options] += " SETTINGS connection_pool_size=8"
+      result = dumper.send(:format_options, options)
+      expect(result).not_to include("ReplicatedMergeTree")
+    end
+
+    it 'returns nil options unchanged' do
+      result = dumper.send(:format_options, nil)
+      expect(result).to be_nil
+    end
+
+    it 'returns options without :options key unchanged' do
+      result = dumper.send(:format_options, { as: "SELECT 1" })
+      expect(result).to eq({ as: "SELECT 1" }.to_s)
+    end
+  end
+
+  describe 'SchemaDumper#dictionary_names' do
+    let(:dumper) { ClickhouseActiverecord::SchemaDumper.new(connection) }
+
+    it 'returns an array' do
+      names = dumper.send(:dictionary_names)
+      expect(names).to be_an(Array)
+    end
+  end
+
+  describe 'SchemaDumper#tables skips dictionary tables' do
+    let(:stream) { StringIO.new }
+    let(:dumper) { ClickhouseActiverecord::SchemaDumper.new(connection) }
+
+    after do
+      connection.execute("DROP TABLE IF EXISTS dict_test_table")
+      connection.execute("DROP DICTIONARY IF EXISTS test_dict")
+    end
+
+    it 'excludes dictionary engine tables' do
+      connection.execute("CREATE TABLE dict_test_table (id UInt64, name String) ENGINE = MergeTree ORDER BY id")
+      connection.execute(<<~SQL)
+        CREATE DICTIONARY test_dict (
+          id UInt64,
+          name String
+        )
+        PRIMARY KEY id
+        SOURCE(CLICKHOUSE(TABLE 'dict_test_table'))
+        LIFETIME(MIN 0 MAX 0)
+        LAYOUT(FLAT())
+      SQL
+
+      dumper.send(:tables, stream)
+      output = stream.string
+
+      expect(output).to include("dict_test_table")
+      expect(output).not_to include("test_dict")
+    end
+  end
+end


### PR DESCRIPTION
When we migrated to the Rails 8.1 with mariadb we got few errors.
This PR will fix an error:
```
undefined method `serialize' for nil
value = cast_type.serialize(value)
```

<img width="1142" height="472" alt="image" src="https://github.com/user-attachments/assets/0f10caaf-0e45-4b09-923c-522d732be89c" />

Also in this PR added small fixes that maybe someone will be interesting too...
Mysql hide credentials, and query retries (for logging db retries looks usefull).
