### PR TITLE
Rails edge (8.2+) compatibility

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -44,7 +44,7 @@ module ActiveRecord
           end
           sql.gsub!(/(\sString)\(\d+\)/, '\1')
 
-          if ::ActiveRecord::version >= Gem::Version.new('8.1')
+          if ::ActiveRecord::version > Gem::Version.new('8.0')
             sql << " DEFAULT #{quote_default_expression_for_column_definition(options[:default], options[:column])}" if options_include_default?(options)
           else
             sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)

--- a/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_creation.rb
@@ -44,7 +44,7 @@ module ActiveRecord
           end
           sql.gsub!(/(\sString)\(\d+\)/, '\1')
 
-          if ::ActiveRecord::version > Gem::Version.new('8.0')
+          if ::ActiveRecord::version >= Gem::Version.new('8.1')
             sql << " DEFAULT #{quote_default_expression_for_column_definition(options[:default], options[:column])}" if options_include_default?(options)
           else
             sql << " DEFAULT #{quote_default_expression(options[:default], options[:column])}" if options_include_default?(options)

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -47,6 +47,11 @@ module ActiveRecord
           end
         end
 
+        def truncate_tables(*table_names)
+          table_names -= views
+          super(*table_names)
+        end
+
         def execute_batch(statements, name = nil, **kwargs)
           statements.each do |statement|
             execute(statement, name, **kwargs)

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -44,14 +44,6 @@ module ActiveRecord
           stack.pop
         end
 
-        def execute(sql, name = nil, format: response_format, settings: {})
-          with_response_format(format) do
-            log(sql, [adapter_name, name].compact.join(' ')) do
-              raw_execute(sql, settings: settings)
-            end
-          end
-        end
-
         def truncate_tables(*table_names)
           table_names -= views
           table_names -= dictionaries
@@ -60,7 +52,19 @@ module ActiveRecord
 
         def execute_batch(statements, name = nil, **kwargs)
           statements.each do |statement|
-            execute(statement, name, **kwargs)
+            intent = QueryIntent.new(
+              adapter: self,
+              processed_sql: statement,
+              name: name,
+              batch: true,
+              binds: kwargs[:binds] || [],
+              prepare: kwargs[:prepare] || false,
+              allow_async: kwargs[:async] || false,
+              allow_retry: kwargs[:allow_retry] || false,
+              materialize_transactions: kwargs[:materialize_transactions] != false
+            )
+            intent.execute!
+            intent.finish
           end
         end
 
@@ -83,31 +87,36 @@ module ActiveRecord
           end
         end
 
-        def exec_insert(sql, name = nil, _binds = [], _pk = nil, _sequence_name = nil, returning: nil)
-          new_sql = sql.sub(/ (DEFAULT )?VALUES/, " VALUES")
-          with_response_format(nil) { execute(new_sql, name) }
-          nil
+        def affected_rows(result)
+          0
+        end
+
+        def _exec_insert(intent, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
+          sql, binds = sql_for_insert(intent.raw_sql, pk, intent.binds, returning)
+          intent.raw_sql = sql
+          intent.binds = binds
+
+          with_response_format(nil) do
+            intent.execute!
+            intent.raw_result
+          end
         end
 
         def internal_exec_query(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false)
-          result = execute(sql, name)
-          columns = result['meta'].map { |m| m['name'] }
-          types = {}
-          result['meta'].each_with_index do |m, i|
-            # need use column name and index after commit in 7.2:
-            # https://github.com/rails/rails/commit/24dbf7637b1d5cd6eb3d7100b8d0f6872c3fee3c
-            types[m['name']] = types[i] = type_map.lookup(m['type'])
-          end
-          ActiveRecord::Result.new(columns, result['data'], types)
+          cast_result(execute(sql, name))
         rescue ActiveRecord::ActiveRecordError => e
           raise e
         rescue StandardError => e
           raise ActiveRecord::ActiveRecordError, "Response: #{e.message}"
         end
 
-        def exec_insert_all(sql, name)
-          with_response_format(nil) { execute(sql, name) }
-          true
+        def exec_insert_all(inserter, name) # :nodoc:
+          intent = internal_build_intent(inserter.to_sql, name)
+
+          with_response_format(nil) do
+            intent.execute!
+            intent.raw_result
+          end
         end
 
         # @link https://clickhouse.com/docs/en/sql-reference/statements/alter/update
@@ -116,10 +125,12 @@ module ActiveRecord
           0
         end
 
-        # @link https://clickhouse.com/docs/en/sql-reference/statements/delete
-        def exec_delete(sql, name = nil, _binds = [])
-          log(sql, "#{adapter_name} #{name}") do
-            statement = Statement.new(sql, format: response_format)
+        # # @link https://clickhouse.com/docs/en/sql-reference/statements/delete
+        def delete(arel, name = nil, binds = [])
+          intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
+
+          log(intent, "#{adapter_name} #{name}") do
+            statement = Statement.new(intent.processed_sql, format: response_format)
             res = request(statement)
             begin
               data = JSON.parse(res.header['x-clickhouse-summary'])
@@ -131,7 +142,7 @@ module ActiveRecord
         end
 
         def tables(name = nil)
-          result = do_system_execute("SHOW TABLES WHERE name NOT LIKE '.inner_id.%'", name)
+          result = do_system_execute("SHOW TABLES WHERE name NOT LIKE '.inner_id.%'", format: 'JSONCompactEachRowWithNamesAndTypes')
           return [] if result.nil?
           result['data'].flatten
         end
@@ -189,9 +200,11 @@ module ActiveRecord
           tables
         end
 
-        def do_system_execute(sql, name = nil, except_params: [])
-          log_with_debug(sql, [adapter_name, name].compact.join(' ')) do
-            raw_execute(sql, except_params: except_params)
+        def do_system_execute(sql, name = nil, format: response_format, settings: {}, except_params: [])
+          with_response_format(format) do
+            log_with_debug(sql, [adapter_name, name].compact.join(' ')) do
+              _raw_execute(sql, settings: settings, except_params: except_params)
+            end
           end
         end
 
@@ -233,7 +246,7 @@ module ActiveRecord
             if (duplicate = inserting.detect { |v| inserting.count(v) > 1 })
               raise "Duplicate migration #{duplicate}. Please renumber your migrations to resolve the conflict."
             end
-            execute(insert_versions_sql(inserting), nil, format: nil, settings: {max_partitions_per_insert_block: [100, inserting.size].max})
+            do_system_execute(insert_versions_sql(inserting), nil, format: nil, settings: {max_partitions_per_insert_block: [100, inserting.size].max})
           end
         end
 
@@ -250,7 +263,7 @@ module ActiveRecord
         protected
 
         def table_structure(table_name)
-          result = do_system_execute("DESCRIBE TABLE `#{table_name}`", table_name)
+          result = do_system_execute("DESCRIBE TABLE `#{table_name}`", format: "JSONCompactEachRowWithNamesAndTypes")
           data = result['data']
 
           raise ActiveRecord::StatementInvalid, "Could not find table '#{table_name}'" if data.empty?
@@ -272,6 +285,27 @@ module ActiveRecord
         end
 
         private
+
+        def perform_query(raw_connection, intent)
+          _raw_execute(intent.processed_sql)
+        end
+
+        def _raw_execute(sql, settings: {}, except_params: {})
+          statement = Statement.new(sql, format: response_format)
+          response = request(statement, settings: settings, except_params: except_params)
+          statement.processed_response(response)
+        end
+
+        def cast_result(raw_result)
+          columns = raw_result['meta'].map { |m| m['name'] }
+          types = {}
+          raw_result['meta'].each_with_index do |m, i|
+            # need use column name and index after commit in 7.2:
+            # https://github.com/rails/rails/commit/24dbf7637b1d5cd6eb3d7100b8d0f6872c3fee3c
+            types[m['name']] = types[i] = type_map.lookup(m['type'])
+          end
+          ActiveRecord::Result.new(columns, raw_result['data'], types)
+        end
 
         def schema_creation
           Clickhouse::SchemaCreation.new(self)
@@ -311,12 +345,6 @@ module ActiveRecord
 
         def has_default_function?(default) # :nodoc:
           (%r{\w+\(.*\)} === default)
-        end
-
-        def raw_execute(sql, settings: {}, except_params: [])
-          statement = Statement.new(sql, format: response_format)
-          response = request(statement, settings: settings, except_params: except_params)
-          statement.processed_response(response)
         end
 
         # Make HTTP request to ClickHouse server
@@ -400,7 +428,7 @@ module ActiveRecord
             #{table_names_sql}
           SQL
 
-          result = do_system_execute(sql)
+          result = execute(sql)
           return {} if result.nil?
 
           result['data'].to_h { |row| [row[0], row[1]] }

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -269,7 +269,7 @@ module ActiveRecord
           default_value = cast_type.cast(default_value)
 
           args = [column_name]
-          args << cast_type if ::ActiveRecord::version > Gem::Version.new('8.0')
+          args << cast_type if ::ActiveRecord::version >= Gem::Version.new('8.1')
           args += [default_value, type_metadata, field[1].include?('Nullable'), default_function]
 
           Clickhouse::Column.new(*args, codec: field[5].presence)

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -242,7 +242,7 @@ module ActiveRecord
           default_value = cast_type.cast(default_value)
 
           args = [column_name]
-          args << cast_type if ::ActiveRecord::version >= Gem::Version.new('8.1')
+          args << cast_type if ::ActiveRecord::version > Gem::Version.new('8.0')
           args += [default_value, type_metadata, field[1].include?('Nullable'), default_function]
 
           Clickhouse::Column.new(*args, codec: field[5].presence)

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -49,6 +49,7 @@ module ActiveRecord
 
         def truncate_tables(*table_names)
           table_names -= views
+          table_names -= dictionaries
           super(*table_names)
         end
 
@@ -141,6 +142,12 @@ module ActiveRecord
 
         def materialized_views(name = nil)
           result = do_system_execute("SHOW TABLES WHERE engine = 'MaterializedView'", name)
+          return [] if result.nil?
+          result['data'].flatten
+        end
+
+        def dictionaries(name = nil)
+          result = do_system_execute("SHOW TABLES WHERE engine = 'Dictionary'", name)
           return [] if result.nil?
           result['data'].flatten
         end

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -89,8 +89,8 @@ module ActiveRecord
           end
         end
 
-        def _exec_insert(intent, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
-          sql, binds = sql_for_insert(intent.raw_sql, pk, intent.binds, returning)
+        def _exec_insert(intent, sequence_name = nil, returning: nil) # :nodoc:
+          sql, binds = sql_for_insert(intent.raw_sql, intent.binds, returning)
           intent.raw_sql = sql
           intent.binds = binds
 

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -71,8 +71,10 @@ module ActiveRecord
         # Execute an SQL query and save the result to a file in stream mode
         # @return [Tempfile]
         def execute_to_file(sql, name = nil, format: response_format, settings: {})
+          intent = internal_build_intent(sql, name)
+
           with_response_format(format) do
-            log(sql, [adapter_name, 'Stream', name].compact.join(' ')) do
+            log(intent, [adapter_name, 'Stream', name].compact.join(' ')) do
               statement = Statement.new(sql, format: response_format)
               result = nil
               @lock.synchronize do
@@ -85,10 +87,6 @@ module ActiveRecord
               result
             end
           end
-        end
-
-        def affected_rows(result)
-          0
         end
 
         def _exec_insert(intent, pk = nil, sequence_name = nil, returning: nil) # :nodoc:
@@ -119,13 +117,17 @@ module ActiveRecord
           end
         end
 
+        def affected_rows(result)
+          0
+        end
+
         # @link https://clickhouse.com/docs/en/sql-reference/statements/alter/update
         def exec_update(sql, name = nil, _binds = [])
           execute(sql, name)
           0
         end
 
-        # # @link https://clickhouse.com/docs/en/sql-reference/statements/delete
+        # @link https://clickhouse.com/docs/en/sql-reference/statements/delete
         def delete(arel, name = nil, binds = [])
           intent = QueryIntent.new(adapter: self, arel: arel, name: name, binds: binds)
 
@@ -238,7 +240,7 @@ module ActiveRecord
           versions = migration_context.migrations.map(&:version)
 
           unless migrated.include?(version)
-            exec_insert "INSERT INTO #{sm_table} (version) VALUES (#{quote(version.to_s)})", nil, nil
+            _exec_insert("INSERT INTO #{sm_table} (version) VALUES (#{quote(version.to_s)})")
           end
 
           inserting = (versions - migrated).select { |v| v < version }
@@ -290,12 +292,6 @@ module ActiveRecord
           _raw_execute(intent.processed_sql)
         end
 
-        def _raw_execute(sql, settings: {}, except_params: {})
-          statement = Statement.new(sql, format: response_format)
-          response = request(statement, settings: settings, except_params: except_params)
-          statement.processed_response(response)
-        end
-
         def cast_result(raw_result)
           columns = raw_result['meta'].map { |m| m['name'] }
           types = {}
@@ -345,6 +341,12 @@ module ActiveRecord
 
         def has_default_function?(default) # :nodoc:
           (%r{\w+\(.*\)} === default)
+        end
+
+        def _raw_execute(sql, settings: {}, except_params: {})
+          statement = Statement.new(sql, format: response_format)
+          response = request(statement, settings: settings, except_params: except_params)
+          statement.processed_response(response)
         end
 
         # Make HTTP request to ClickHouse server

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -240,7 +240,8 @@ module ActiveRecord
           versions = migration_context.migrations.map(&:version)
 
           unless migrated.include?(version)
-            _exec_insert("INSERT INTO #{sm_table} (version) VALUES (#{quote(version.to_s)})")
+            intent = internal_build_intent("INSERT INTO #{sm_table} (version) VALUES (#{quote(version.to_s)})", "migrate_#{sm_table}")
+            _exec_insert(intent)
           end
 
           inserting = (versions - migrated).select { |v| v < version }

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -349,7 +349,7 @@ module ActiveRecord
 
       def primary_keys(table_name)
         if server_version.to_f >= 23.4
-          structure = do_system_execute("SHOW COLUMNS FROM `#{table_name}`")
+          structure = do_system_execute("SHOW COLUMNS FROM `#{table_name}`", format: 'JSONCompact')
           return structure['data'].select {|m| m[3]&.include?('PRI') }.pluck(0)
         end
 
@@ -386,7 +386,7 @@ module ActiveRecord
           drop_table(table_name, options.merge(if_exists: true))
         end
 
-        execute(schema_creation.accept(td), settings: request_settings)
+        do_system_execute(schema_creation.accept(td), settings: request_settings)
       end
 
       def create_table(table_name, request_settings: {}, **options, &block)
@@ -403,7 +403,7 @@ module ActiveRecord
           drop_table(table_name, options.merge(if_exists: true))
         end
 
-        execute(schema_creation.accept(td), settings: request_settings)
+        do_system_execute(schema_creation.accept(td), settings: request_settings)
 
         if options[:with_distributed]
           distributed_table_name = options.delete(:with_distributed)

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -24,7 +24,7 @@ module ClickhouseActiverecord
       materialized_view_tables = @connection.materialized_views.sort
       sorted_tables = @connection.tables.sort - view_tables - materialized_view_tables
 
-      (sorted_tables + view_tables + materialized_view_tables).each do |table_name|
+      (sorted_tables + materialized_view_tables + view_tables).each do |table_name|
         table(table_name, stream) unless ignored?(table_name)
       end
     end

--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -176,7 +176,7 @@ module CoreExtensions
       end
 
       def build_arel(connection_or_aliases = nil, aliases = nil)
-        requirement = Gem::Requirement.new('>= 7.2', '< 8.1')
+        requirement = Gem::Requirement.new('>= 7.2', '<= 8.0')
 
         if requirement.satisfied_by?(::ActiveRecord::version)
           arel = super

--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -2,10 +2,6 @@ module CoreExtensions
   module ActiveRecord
     module Relation
 
-      def self.prepended(base)
-        base::VALID_UNSCOPING_VALUES << :final << :settings
-      end
-
       def reverse_order!
         return super unless connection.is_a?(::ActiveRecord::ConnectionAdapters::ClickhouseAdapter)
 
@@ -169,6 +165,35 @@ module CoreExtensions
         self
       end
 
+      def unscope!(*args) # :nodoc:
+        self.unscope_values |= args
+
+        args.each do |scope|
+          case scope
+          when Symbol
+            scope = :left_outer_joins if scope == :left_joins
+            if !_valid_unscoping_values.include?(scope)
+              raise ArgumentError, "Called unscope() with invalid unscoping argument ':#{scope}'. Valid arguments are :#{valid_unscoping_values.to_a.join(", :")}."
+            end
+            assert_modifiable!
+            @values.delete(scope)
+          when Hash
+            scope.each do |key, target_value|
+              if key != :where
+                raise ArgumentError, "Hash arguments in .unscope(*args) must have :where as the key."
+              end
+
+              target_values = resolve_arel_attributes(Array.wrap(target_value))
+              self.where_clause = where_clause.except(*target_values)
+            end
+          else
+            raise ArgumentError, "Unrecognized scoping: #{args.inspect}. Use .unscope(where: :attribute_name) or .unscope(:order), for example."
+          end
+        end
+
+        self
+      end
+
       private
 
       def check_command!(cmd)
@@ -217,6 +242,11 @@ module CoreExtensions
         else
           super
         end
+      end
+
+      # alternative method to avoid redefining the const +VALID_UNSCOPING_VALUES+
+      def _valid_unscoping_values
+        Set.new(::ActiveRecord::Relation::VALID_UNSCOPING_VALUES.to_a + [:settings, :final])
       end
     end
   end

--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -176,7 +176,7 @@ module CoreExtensions
       end
 
       def build_arel(connection_or_aliases = nil, aliases = nil)
-        requirement = Gem::Requirement.new('>= 7.2', '<= 8.0')
+        requirement = Gem::Requirement.new('>= 7.2', '< 8.1')
 
         if requirement.satisfied_by?(::ActiveRecord::version)
           arel = super

--- a/lib/core_extensions/active_record/schema_migration.rb
+++ b/lib/core_extensions/active_record/schema_migration.rb
@@ -21,6 +21,10 @@ module CoreExtensions
           distributed_suffix = ''
         end
 
+        if full_config[:cluster_name]
+          table_options.merge!(options: 'ReplicatedReplacingMergeTree(ver) ORDER BY (version)')
+        end
+
         connection.create_table(table_name + distributed_suffix.to_s, **table_options) do |t|
           t.string :version, **version_options
           t.column :active, 'Int8', null: false, default: '1'
@@ -44,6 +48,7 @@ module CoreExtensions
         sm.project(arel_table[primary_key])
         sm.order(arel_table[primary_key].asc)
         sm.where([arel_table['active'].eq(1)])
+        sm.settings({max_replica_delay_for_distributed_queries: 1})
 
         connection.select_values(sm, "#{self.class} Load")
       end

--- a/spec/single/http_auth_spec.rb
+++ b/spec/single/http_auth_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'HTTP auth modes' do
       response
     end
 
-    adapter.execute('SELECT 1', settings: settings)
+    adapter.do_system_execute('SELECT 1', settings: settings)
     request_payload
   end
 

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Model', :migrations do
       end
 
       it 'also works when a different format is passed as a keyword' do
-        result = Model.connection.execute('SELECT 1 AS t', format: 'JSONCompact')
+        result = Model.connection.do_system_execute('SELECT 1 AS t', format: 'JSONCompact')
         expect(result['data']).to eq([[1]])
         expect(result['meta']).to eq([{ 'name' => 't', 'type' => 'UInt8' }])
       end
@@ -850,7 +850,7 @@ RSpec.describe 'Model', :migrations do
       before do
         # Create table with JSON column
         json_model.connection.execute('DROP TABLE IF EXISTS json_test_table')
-        json_model.connection.execute(<<~SQL, nil, settings: { allow_experimental_json_type: 1 })
+        json_model.connection.do_system_execute(<<~SQL, nil, settings: { allow_experimental_json_type: 1 })
           CREATE TABLE json_test_table (
             id UInt64,
             properties JSON,

--- a/spec/single/schema_statements_spec.rb
+++ b/spec/single/schema_statements_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe 'ActiveRecord::ConnectionAdapters::Clickhouse::SchemaStatements' 
 
     it 'truncates multiple tables' do
       connection.execute('CREATE TABLE truncate_test2 (id UInt64, value Int32) ENGINE = MergeTree ORDER BY id')
-      connection.exec_insert("INSERT INTO truncate_test (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
-      connection.exec_insert("INSERT INTO truncate_test2 (id, value) VALUES (1, 100), (2, 200)")
+      connection.insert("INSERT INTO truncate_test (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+      connection.insert("INSERT INTO truncate_test2 (id, value) VALUES (1, 100), (2, 200)")
 
       expect(connection.select_value('SELECT count() FROM truncate_test').to_i).to eq(2)
       expect(connection.select_value('SELECT count() FROM truncate_test2').to_i).to eq(2)
@@ -41,7 +41,7 @@ RSpec.describe 'ActiveRecord::ConnectionAdapters::Clickhouse::SchemaStatements' 
         LIFETIME(MIN 0 MAX 0)
         LAYOUT(FLAT())
       SQL
-      connection.exec_insert("INSERT INTO truncate_test (id, name) VALUES (1, 'Alice')")
+      connection.insert("INSERT INTO truncate_test (id, name) VALUES (1, 'Alice')")
 
       expect { connection.truncate_tables(*connection.tables) }.not_to raise_error
 


### PR DESCRIPTION
Updates `clickhouse-activerecord` to use the new internal [QueryIntent](https://github.com/rails/rails/pull/55897) API introduced in Rails edge/version 8.2. The QueryIntent API changes the internal API for ActiveRecord connection adapters quite significantly so I don't think it will be easy to maintain backwards compatibility with previous versions of Rails.

All tests are passing and we are successfully running this in production with the latest Rails edge. We will be happy to accept any feedback to improve the PR and would even be willing to test in production if our application tests pass.