### PR TITLE
Detect Array columns via Column#array

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/column.rb
+++ b/lib/active_record/connection_adapters/clickhouse/column.rb
@@ -21,6 +21,15 @@ module ActiveRecord
           default_kind.materialized? || default_kind.alias?
         end
 
+        # Whether the column holds a ClickHouse `Array(...)` type.
+        #
+        # ActiveRecord core never calls this, but tooling such as annotaterb
+        # detects array columns via `column.respond_to?(:array) && column.array`,
+        # so the base adapter's missing `array` reader left them undetected.
+        def array
+          sql_type.start_with?('Array(')
+        end
+
         private
 
         def deduplicated

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -165,11 +165,11 @@ module ClickhouseActiverecord
     end
 
     def schema_array(column)
-      (column.sql_type =~ /Array\(/).nil? ? nil : true
+      column.array ? true : nil
     end
 
     def schema_map(column)
-      if column.sql_type =~ /Map\(([^,]+),\s*(Array)\)/
+      if column.sql_type =~ /Map\([^,]+,\s*Array\(/
         return :array
       end
 

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -543,6 +543,18 @@ RSpec.describe 'Model', :migrations do
       quietly { ActiveRecord::MigrationContext.new(migrations_dir).up }
     end
 
+    describe '#array' do
+      it 'reports array columns as arrays' do
+        expect(model.columns_hash['array_datetime'].array).to be_truthy
+        expect(model.columns_hash['array_string'].array).to be_truthy
+        expect(model.columns_hash['array_int'].array).to be_truthy
+      end
+
+      it 'does not report scalar columns as arrays' do
+        expect(model.columns_hash['date'].array).to be_falsey
+      end
+    end
+
     describe '#create' do
       it 'creates a new record' do
         expect {
@@ -597,6 +609,13 @@ RSpec.describe 'Model', :migrations do
     before do
       migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'add_map_datetime')
       quietly { ActiveRecord::MigrationContext.new(migrations_dir).up }
+    end
+
+    describe '#array' do
+      it 'does not report map columns as arrays' do
+        expect(model.columns_hash['map_string'].array).to be_falsey
+        expect(model.columns_hash['map_array_string'].array).to be_falsey
+      end
     end
 
     describe '#create' do


### PR DESCRIPTION
The base ActiveRecord Column does not define array. Each adapter that supports arrays adds it on its own Column subclass (e.g. PostgreSQL). The ClickHouse Column never did, so tooling that detects array columns via `column.respond_to?(:array) && column.array` (such as annotaterb) silently treated `Array(...)` columns as their scalar subtype.

Add `Column#array`, matching the top-level `Array(...)` SQL type, and have the schema dumper reuse it instead of re-deriving array-ness from a regex. Also fix the schema dumper's map-value regex so `Map(_, Array(_))` columns are dumped as `map: :array` (the intended single-option form) rather than relying on the previous match-anywhere behavior; both forms reload to the same SQL type.