### PR TITLE
Add support for FINAL when joining tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,13 @@ User.joins(:actions).using(:group_id)
 # Clickhouse User Load (10.3ms)  SELECT users.* FROM users INNER JOIN actions USING group_id
 #=> #<ActiveRecord::Relation [#<User *** >]>
 
+# `final` only applies the FINAL modifier to the primary FROM table. Use
+# `joins_final` to also apply FINAL to a joined table (the join is added for
+# you, like `joins`). Pass association names; joins are matched by table name.
+User.final.joins_final(:actions)
+# Clickhouse User Load (10.3ms)  SELECT users.* FROM users FINAL INNER JOIN actions FINAL ON actions.user_id = users.id
+#=> #<ActiveRecord::Relation [#<User *** >]>
+
 User.window('x', order: 'date', partition: 'name', rows: 'UNBOUNDED PRECEDING').select('sum(value) OVER x')
 # SELECT sum(value) OVER x FROM users WINDOW x AS (PARTITION BY name ORDER BY date ROWS UNBOUNDED PRECEDING)
 #=> #<ActiveRecord::Relation [#<User *** >]>

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -2,6 +2,7 @@
 
 require 'arel/visitors/clickhouse'
 require 'arel/nodes/final'
+require 'arel/nodes/final_table'
 require 'arel/nodes/grouping_sets'
 require 'arel/nodes/settings'
 require 'arel/nodes/using'
@@ -65,6 +66,7 @@ module ActiveRecord
   module ModelSchema
     module ClassMethods
       delegate :final, :final!,
+               :joins_final, :joins_final!,
                :group_by_grouping_sets, :group_by_grouping_sets!,
                :settings, :settings!,
                :window, :window!,

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -67,6 +67,7 @@ module ActiveRecord
     module ClassMethods
       delegate :final, :final!,
                :joins_final, :joins_final!,
+               :left_joins_final, :left_joins_final!,
                :group_by_grouping_sets, :group_by_grouping_sets!,
                :settings, :settings!,
                :window, :window!,

--- a/lib/arel/nodes/final_table.rb
+++ b/lib/arel/nodes/final_table.rb
@@ -1,0 +1,10 @@
+module Arel # :nodoc: all
+  module Nodes
+    # Wraps the table source of a JOIN so the ClickHouse visitor renders
+    # `<table> FINAL ON ...` for that join. Built by
+    # ActiveRecord::Relation#joins_final, which marks the matching join
+    # sources after Arel has been constructed.
+    class FinalTable < Arel::Nodes::Unary
+    end
+  end
+end

--- a/lib/arel/visitors/clickhouse.rb
+++ b/lib/arel/visitors/clickhouse.rb
@@ -88,6 +88,16 @@ module Arel
         collector
       end
 
+      # Renders the FINAL modifier for a single JOIN source, e.g.
+      # `INNER JOIN espm_binaries FINAL ON ...`. The join visitors inherited
+      # from ToSql all emit their table via `visit o.left`, so wrapping that
+      # table in a FinalTable node is enough to add FINAL to any join type.
+      def visit_Arel_Nodes_FinalTable(o, collector)
+        collector = visit o.expr, collector
+        collector << ' FINAL'
+        collector
+      end
+
       def visit_Arel_Nodes_GroupingSets(o, collector)
         collector << 'GROUPING SETS '
         grouping_array_or_grouping_element(o.expr, collector)

--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -3,7 +3,7 @@ module CoreExtensions
     module Relation
 
       def self.prepended(base)
-        base::VALID_UNSCOPING_VALUES << :final << :settings
+        base::VALID_UNSCOPING_VALUES << :final << :settings << :joins_final
       end
 
       def reverse_order!
@@ -88,6 +88,49 @@ module CoreExtensions
 
       def final_value
         @values.fetch(:final, nil)
+      end
+
+      # Apply the FINAL modifier to one or more joined tables. Unlike #final,
+      # which only adds FINAL to the query's primary FROM table, #joins_final
+      # adds the join(s) and renders FINAL on the joined table so ClickHouse
+      # merges those rows before joining.
+      # For example:
+      #
+      #   AppControlEvent.final.joins_final(:espm_binary)
+      #   # SELECT ... FROM espm_app_control_events FINAL
+      #   #   INNER JOIN espm_binaries FINAL ON ...
+      #
+      # Each argument is an association name and is added as a join (like
+      # #joins); FINAL is then rendered on the joined table. Joins are matched
+      # by table name, so if the same table is joined more than once every join
+      # of that table receives FINAL. An
+      # <tt>ActiveRecord::ActiveRecordError</tt> will be raised if the database
+      # is not ClickHouse.
+      #
+      # @param [Array] args
+      def joins_final(*args)
+        spawn.joins_final!(*args)
+      end
+
+      # @param [Array] args
+      def joins_final!(*args)
+        check_command!('FINAL')
+        joins!(*args)
+        self.joins_final_values |= args
+        self
+      end
+
+      def joins_final_values
+        @values.fetch(:joins_final, ::ActiveRecord::QueryMethods::FROZEN_EMPTY_ARRAY)
+      end
+
+      def joins_final_values=(value)
+        if ::ActiveRecord::version >= Gem::Version.new('7.2')
+          assert_modifiable!
+        else
+          assert_mutability!
+        end
+        @values[:joins_final] = value
       end
 
       # GROUPING SETS allows you to specify multiple groupings in the GROUP BY clause.
@@ -175,6 +218,50 @@ module CoreExtensions
         raise ::ActiveRecord::ActiveRecordError, cmd + ' is a ClickHouse specific query clause' unless connection.is_a?(::ActiveRecord::ConnectionAdapters::ClickhouseAdapter)
       end
 
+      # Wrap the left (table) side of every join source that matches a
+      # requested #joins_final argument in an Arel::Nodes::FinalTable so the
+      # ClickHouse visitor renders FINAL on that join. Called before
+      # +arel.final!+ so the join source is still the plain JoinSource (and not
+      # yet wrapped in the FROM-level Final node).
+      def mark_final_joins!(arel)
+        names = final_join_table_names
+        return if names.empty?
+
+        arel.join_sources.each do |join|
+          next unless join.respond_to?(:left) && join.respond_to?(:left=)
+
+          left = join.left
+          next if left.is_a?(::Arel::Nodes::FinalTable)
+          next unless final_join_match?(left, names)
+
+          join.left = ::Arel::Nodes::FinalTable.new(left)
+        end
+      end
+
+      # Resolve the #joins_final arguments to the set of table names that
+      # should carry FINAL. Association names are mapped to their table;
+      # anything else is treated as a literal table name.
+      def final_join_table_names
+        joins_final_values.flatten.filter_map do |arg|
+          case arg
+          when Symbol, String
+            reflection = klass.reflect_on_association(arg.to_sym)
+            reflection ? reflection.table_name : arg.to_s
+          end
+        end.to_set
+      end
+
+      # Does the join's table source match one of the requested FINAL names?
+      # Handles both Arel::Table (name) and Arel::Nodes::TableAlias (alias name
+      # plus the underlying relation's name).
+      def final_join_match?(left, names)
+        candidates = []
+        candidates << left.name if left.respond_to?(:name)
+        candidates << left.table_alias if left.respond_to?(:table_alias) && left.table_alias
+        candidates << left.relation.name if left.respond_to?(:relation) && left.relation.respond_to?(:name)
+        candidates.any? { |c| names.include?(c.to_s) }
+      end
+
       def build_arel(connection_or_aliases = nil, aliases = nil)
         requirement = Gem::Requirement.new('>= 7.2', '< 8.1')
 
@@ -184,6 +271,7 @@ module CoreExtensions
           arel = super(connection_or_aliases)
         end
 
+        mark_final_joins!(arel) if joins_final_values.present?
         arel.final! if final_value
         arel.limit_by(*@values[:limit_by]) if @values[:limit_by].present?
         arel.settings(settings_values) unless settings_values.empty?

--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -120,6 +120,36 @@ module CoreExtensions
         self
       end
 
+      # Like #joins_final, but adds the join(s) as LEFT OUTER JOINs (via
+      # #left_outer_joins) and renders FINAL on the joined table. Use this when
+      # the joined rows must be preserved even with no match (e.g. an optional
+      # catalog lookup) while still merging the joined table with FINAL.
+      # For example:
+      #
+      #   AppControlEvent.left_joins_final(:espm_binary)
+      #   # SELECT ... FROM espm_app_control_events
+      #   #   LEFT OUTER JOIN espm_binaries FINAL ON ...
+      #
+      # Each argument is an association name and is added as a left outer join
+      # (like #left_outer_joins); FINAL is then rendered on the joined table.
+      # Joins are matched by table name, so if the same table is joined more
+      # than once every join of that table receives FINAL. An
+      # <tt>ActiveRecord::ActiveRecordError</tt> will be raised if the database
+      # is not ClickHouse.
+      #
+      # @param [Array] args
+      def left_joins_final(*args)
+        spawn.left_joins_final!(*args)
+      end
+
+      # @param [Array] args
+      def left_joins_final!(*args)
+        check_command!('FINAL')
+        left_outer_joins!(*args)
+        self.joins_final_values |= args
+        self
+      end
+
       def joins_final_values
         @values.fetch(:joins_final, ::ActiveRecord::QueryMethods::FROZEN_EMPTY_ARRAY)
       end

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -507,6 +507,14 @@ RSpec.describe 'Model', :migrations do
         expect(Model.left_joins_final(:joins)).to be_a(ActiveRecord::Relation)
       end
 
+      it 'collapses to a single FINAL join when the same association is also added via #joins_final' do
+        # ActiveRecord deduplicates an association present in both joins and
+        # left_outer_joins into one INNER JOIN (INNER wins), and the shared
+        # joins_final_values store dedups via |=, so FINAL is applied once.
+        sql = Model.joins_final(:joins).left_joins_final(:joins).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample INNER JOIN joins FINAL ON joins.model_id = sample.event_name')
+      end
+
       it 'executes against ClickHouse and merges the FINAL-joined table' do
         Model.create!(date: date, event_name: 'left-final-join')
         Model.create!(date: date, event_name: 'left-final-join')

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -471,6 +471,55 @@ RSpec.describe 'Model', :migrations do
       end
     end
 
+    describe '#left_joins_final' do
+      it 'adds FINAL to a LEFT OUTER joined table' do
+        sql = Model.left_joins_final(:joins).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample LEFT OUTER JOIN joins FINAL ON joins.model_id = sample.event_name')
+      end
+
+      it 'applies FINAL to both the FROM table and the left join when combined with #final' do
+        sql = Model.final.left_joins_final(:joins).where(date: '2023-07-21').to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample FINAL LEFT OUTER JOIN joins FINAL ON joins.model_id = sample.event_name WHERE sample.date = \'2023-07-21\'')
+      end
+
+      it 'does not duplicate a join already added via #left_outer_joins' do
+        sql = Model.left_outer_joins(:joins).left_joins_final(:joins).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample LEFT OUTER JOIN joins FINAL ON joins.model_id = sample.event_name')
+      end
+
+      it 'does not add FINAL to the FROM table on its own' do
+        sql = Model.left_joins_final(:joins).to_sql
+        expect(sql).not_to match(/FROM sample FINAL/)
+      end
+
+      it 'keeps the join LEFT OUTER (does not promote to INNER)' do
+        sql = Model.left_joins_final(:joins).to_sql
+        expect(sql).to include('LEFT OUTER JOIN joins FINAL')
+        expect(sql).not_to match(/INNER JOIN joins/)
+      end
+
+      it 'can be removed with unscope, keeping the plain left join' do
+        sql = Model.left_joins_final(:joins).unscope(:joins_final).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample LEFT OUTER JOIN joins ON joins.model_id = sample.event_name')
+      end
+
+      it 'is chainable (returns a relation)' do
+        expect(Model.left_joins_final(:joins)).to be_a(ActiveRecord::Relation)
+      end
+
+      it 'executes against ClickHouse and merges the FINAL-joined table' do
+        Model.create!(date: date, event_name: 'left-final-join')
+        Model.create!(date: date, event_name: 'left-final-join')
+
+        relation = Model.final.left_joins_final(:twins).where(sample: { event_name: 'left-final-join' })
+        expect(relation.to_sql).to include('LEFT OUTER JOIN').and include('FINAL ON')
+        # The sample table is a ReplacingMergeTree: FINAL dedups the two rows to
+        # one on both the FROM side and the self-joined side, so the join
+        # produces a single row.
+        expect(relation.count).to eq(1)
+      end
+    end
+
     describe '#limit_by' do
       it 'works' do
         sql = Model.limit_by(1, :event_name).to_sql

--- a/spec/single/model_spec.rb
+++ b/spec/single/model_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe 'Model', :migrations do
   class Model < ActiveRecord::Base
     self.table_name = 'sample'
     has_many :joins, class_name: 'ModelJoin', primary_key: 'event_name'
+    # Self-referential association to the sample table (a ReplacingMergeTree,
+    # which supports FINAL) so the FINAL join can actually be executed.
+    has_many :twins, class_name: 'Model', foreign_key: 'event_name', primary_key: 'event_name'
   end
   class ModelPk < ActiveRecord::Base
     self.table_name = 'sample'
@@ -422,6 +425,49 @@ RSpec.describe 'Model', :migrations do
       it 'works with JOINs' do
         sql = Model.final.joins(:joins).where(date: '2023-07-21').to_sql
         expect(sql).to eq('SELECT sample.* FROM sample FINAL INNER JOIN joins ON joins.model_id = sample.event_name WHERE sample.date = \'2023-07-21\'')
+      end
+    end
+
+    describe '#joins_final' do
+      it 'adds FINAL to the joined table' do
+        sql = Model.joins_final(:joins).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample INNER JOIN joins FINAL ON joins.model_id = sample.event_name')
+      end
+
+      it 'applies FINAL to both the FROM table and the join when combined with #final' do
+        sql = Model.final.joins_final(:joins).where(date: '2023-07-21').to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample FINAL INNER JOIN joins FINAL ON joins.model_id = sample.event_name WHERE sample.date = \'2023-07-21\'')
+      end
+
+      it 'does not duplicate a join already added via #joins' do
+        sql = Model.joins(:joins).joins_final(:joins).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample INNER JOIN joins FINAL ON joins.model_id = sample.event_name')
+      end
+
+      it 'does not add FINAL to the FROM table on its own' do
+        sql = Model.joins_final(:joins).to_sql
+        expect(sql).not_to match(/FROM sample FINAL/)
+      end
+
+      it 'can be removed with unscope, keeping the plain join' do
+        sql = Model.joins_final(:joins).unscope(:joins_final).to_sql
+        expect(sql).to eq('SELECT sample.* FROM sample INNER JOIN joins ON joins.model_id = sample.event_name')
+      end
+
+      it 'is chainable (returns a relation)' do
+        expect(Model.joins_final(:joins)).to be_a(ActiveRecord::Relation)
+      end
+
+      it 'executes against ClickHouse and merges the FINAL-joined table' do
+        Model.create!(date: date, event_name: 'final-join')
+        Model.create!(date: date, event_name: 'final-join')
+
+        relation = Model.final.joins_final(:twins).where(sample: { event_name: 'final-join' })
+        expect(relation.to_sql).to include('FINAL ON')
+        # The sample table is a ReplacingMergeTree: FINAL dedups the two rows to
+        # one on both the FROM side and the self-joined side, so the join
+        # produces a single row.
+        expect(relation.count).to eq(1)
       end
     end
 


### PR DESCRIPTION
## Summary

ClickHouse's `final` modifier only wraps the query's primary `FROM` source, so `.final.joins(:assoc)` emits a plain `INNER JOIN <table>` against the *un-merged* joined table (wrong row mapping, duplicates). This adds two query methods that render `FINAL` on the *joined* table:

```ruby
AppControlEvent.final.joins_final(:binary)
# SELECT ... FROM app_control_events FINAL
#   INNER JOIN binaries FINAL ON ...

AppControlEvent.left_joins_final(:binary)
# SELECT ... FROM app_control_events
#   LEFT OUTER JOIN binaries FINAL ON ...
```

`joins_final` adds the association like `joins` (INNER JOIN); `left_joins_final` adds it like `left_outer_joins` (LEFT OUTER JOIN) for optional joins whose rows must be preserved when there is no match — while still merging the joined table with `FINAL`.

## Implementation

- **`Arel::Nodes::FinalTable`** — a new `Unary` marker node wrapping a join's table source. Because every Arel join visitor (`InnerJoin`, `OuterJoin`, …) emits its table via `visit o.left`, a single `visit_Arel_Nodes_FinalTable` covers **all** join types.
- **`Relation#joins_final` / `#left_joins_final`** (+ `!` variants) add the join(s), record the requested association names in `joins_final_values`, and — in `build_arel`, before the FROM-level `FINAL` is applied — wrap matching join sources in `FinalTable`.
- Joins are matched by table name (handles `Arel::Table` and `TableAlias`). If the same physical table is joined more than once, every join of that table receives `FINAL` (documented on the methods).
- Class-level delegation (`Model.joins_final`), chaining, dedup with an existing `.joins`, and `unscope(:joins_final)` are all supported.
- Raises `ActiveRecord::ActiveRecordError` on non-ClickHouse connections, consistent with the existing `final`/`settings` clauses.

## Changes

- `lib/arel/nodes/final_table.rb` — new marker node
- `lib/arel/visitors/clickhouse.rb` — `visit_Arel_Nodes_FinalTable`
- `lib/active_record/connection_adapters/clickhouse_adapter.rb` — require the node, delegate the new methods
- `lib/core_extensions/active_record/relation.rb` — the query methods, join-marking, and `unscope` support
- `README.md`, `CHANGELOG.md` — docs
- `spec/single/model_spec.rb` — specs covering generated SQL, FINAL combination with `.final`, dedup, `unscope`, INNER-vs-LEFT, mixed same-association use, and real execution against ClickHouse (`FINAL` requires a supporting engine, so the execution test self-joins the `sample` table)
