### PR TITLE
Use `lease_connection` instead of `connection` for Rails 7.2+

### DIFF
--- a/lib/core_extensions/active_record/relation.rb
+++ b/lib/core_extensions/active_record/relation.rb
@@ -7,7 +7,8 @@ module CoreExtensions
       end
 
       def reverse_order!
-        return super unless connection.is_a?(::ActiveRecord::ConnectionAdapters::ClickhouseAdapter)
+        conn = respond_to?(:lease_connection) ? lease_connection : connection
+        return super unless conn.is_a?(::ActiveRecord::ConnectionAdapters::ClickhouseAdapter)
 
         orders = order_values.uniq.reject(&:blank?)
         return super unless orders.empty? && !primary_key


### PR DESCRIPTION
This allows applications using clickhouse-activerecord to set `config.active_record.permanent_connection_checkout = :disallowed` without errors being raised.

https://guides.rubyonrails.org/configuring.html#config-active-record-permanent-connection-checkout