### PR TITLE
Fix database name resolution when using URL-only config

### DIFF
--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -14,7 +14,7 @@ module ClickhouseActiverecord
 
     def create
       establish_master_connection
-      connection.create_database @configuration.database
+      connection.create_database database_name
     rescue ActiveRecord::StatementInvalid => e
       if e.cause.to_s.include?('already exists')
         raise ActiveRecord::DatabaseAlreadyExists
@@ -25,7 +25,7 @@ module ClickhouseActiverecord
 
     def drop
       establish_master_connection
-      connection.drop_database @configuration.database
+      connection.drop_database database_name
     end
 
     def purge
@@ -43,9 +43,9 @@ module ClickhouseActiverecord
                             .map { |function| function.gsub('\\n', "\n") }
 
       # get all tables
-      table_defs = connection.execute("SHOW TABLES FROM #{@configuration.database} WHERE name NOT LIKE '.inner_id.%'")['data']
+      table_defs = connection.execute("SHOW TABLES FROM #{database_name} WHERE name NOT LIKE '.inner_id.%'")['data']
                              .flatten
-                             .map { |name| connection.show_create_table(name, single_line: false).gsub("#{@configuration.database}.", '') }
+                             .map { |name| connection.show_create_table(name, single_line: false).gsub("#{database_name}.", '') }
 
       # separate views from tables
       views, tables = table_defs.partition { |sql| sql.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) }
@@ -122,6 +122,11 @@ module ClickhouseActiverecord
 
     def establish_master_connection
       establish_connection @configuration
+    end
+
+    def database_name
+      @configuration.database.presence ||
+        URI.parse(@configuration.configuration_hash[:url]).path.delete_prefix('/')
     end
 
     def check_target_version

--- a/spec/single/tasks_spec.rb
+++ b/spec/single/tasks_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'clickhouse-activerecord/tasks'
+
+RSpec.describe ClickhouseActiverecord::Tasks do
+  let(:configuration) do
+    instance_double(
+      ActiveRecord::DatabaseConfigurations::HashConfig,
+      database: database,
+      configuration_hash: configuration_hash,
+    )
+  end
+  let(:tasks) { described_class.new(configuration) }
+
+  describe '#database_name' do
+    subject { tasks.send(:database_name) }
+
+    context 'when database is set explicitly in config' do
+      let(:database) { 'my_database' }
+      let(:configuration_hash) { { url: nil } }
+
+      it { is_expected.to eq('my_database') }
+    end
+
+    context 'when database is nil but present in url' do
+      let(:database) { nil }
+      let(:configuration_hash) { { url: 'clickhouse://user:pass@host:8123/my_database' } }
+
+      it { is_expected.to eq('my_database') }
+    end
+
+    context 'when database is empty string but present in url' do
+      let(:database) { '' }
+      let(:configuration_hash) { { url: 'clickhouse://user:pass@host:8123/my_database' } }
+
+      it { is_expected.to eq('my_database') }
+    end
+
+    context 'when both database and url are set, explicit database takes precedence' do
+      let(:database) { 'explicit_database' }
+      let(:configuration_hash) { { url: 'clickhouse://user:pass@host:8123/url_database' } }
+
+      it { is_expected.to eq('explicit_database') }
+    end
+  end
+end


### PR DESCRIPTION
Tasks methods (create, drop, structure_dump) call `@configuration.database` directly, which only reads the explicit database: key in the config. 

When the adapter is configured via a single url: key (e.g. clickhouse://user:pass@host:8123/mydb), this returns nil, producing invalid SQL.