### PR TITLE
Harden HTTP connection: open_timeout, TLS verification, retry, query limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ default: &default
   read_timeout: 300 # change network timeouts, by default 60 seconds
   write_timeout: 300
   keep_alive_timeout: 300
+  open_timeout: 5 # timeout for establishing the TCP connection itself, optional (Net::HTTP's default applies if unset)
+  insecure: false # optional, skip TLS certificate verification (default: true, matching prior behavior - set to false to verify)
+  sslca: /path/to/ca.pem # optional, custom CA bundle for TLS verification
+  max_execution_time: 25 # optional, server-side query time limit in seconds, sent as a ClickHouse session setting
+  cancel_http_readonly_queries_on_client_close: true # optional, tell the server to abort a SELECT once the client disconnects
 ```
 
 ### URL-based configuration
@@ -52,10 +57,10 @@ default: &default
 Optional settings can be passed as query parameters:
 
 ```
-clickhouse://username:password@localhost:8123/database?ssl=true&http_auth=basic&read_timeout=300&write_timeout=300&keep_alive_timeout=300&debug=false&cluster_name=my_cluster
+clickhouse://username:password@localhost:8123/database?ssl=true&http_auth=basic&read_timeout=300&write_timeout=300&keep_alive_timeout=300&open_timeout=5&debug=false&cluster_name=my_cluster
 ```
 
-Supported query parameters: `ssl` (true/false), `debug` (true/false), `http_auth` (query_params/basic/x_clickhouse_headers), `read_timeout`, `write_timeout`, `keep_alive_timeout` (integers), `cluster_name`, `sslca`.
+Supported query parameters: `ssl` (true/false), `debug` (true/false), `insecure` (true/false), `http_auth` (query_params/basic/x_clickhouse_headers), `open_timeout`, `read_timeout`, `write_timeout`, `keep_alive_timeout`, `max_execution_time` (integers), `cancel_http_readonly_queries_on_client_close` (true/false), `cluster_name`, `sslca`.
 
 If both a `url` and explicit keys are provided, the explicit keys take precedence:
 
@@ -102,6 +107,33 @@ clickhouse:
 - `http_auth: x_clickhouse_headers` sends `X-ClickHouse-User`, `X-ClickHouse-Key`, and `X-ClickHouse-Database` headers.
 - `http_auth: basic` sends `Authorization: Basic ...` and keeps `database` in URL params.
 - `http_auth: query_params` sends `user`, `password`, and `database` in URL params (same as omitting `http_auth`).
+
+### Connection hardening
+
+- **TLS verification is now configurable.** Every connection has always been made with
+  `verify_mode: OpenSSL::SSL::VERIFY_NONE`, so an SSL connection to ClickHouse never actually
+  checked the server's certificate. That remains the default (`insecure: true`) to avoid
+  breaking existing setups; set `insecure: false` to turn verification on, optionally with
+  `sslca` pointing at your CA bundle.
+- **`open_timeout`** bounds how long establishing the underlying TCP connection is allowed to
+  take. It's optional and unset by default (`Net::HTTP`'s own default applies), unlike
+  `read_timeout`/`write_timeout` which only apply once a connection exists - a network path that
+  never completes the TCP handshake (a dead route, a security group silently dropping packets)
+  previously had no bound here at all.
+- **Read queries (`SELECT`) are retried once** on a fresh connection when the failure happens
+  before the server responds at all (`Net::OpenTimeout`, `EOFError`, `ECONNRESET`, `IOError`) -
+  the kind of failure a stale pooled connection produces. Writes are never retried, and
+  `Net::ReadTimeout` (the server received the query and hasn't answered yet) is deliberately
+  **not** retried on any query - re-sending a query that's already loading the server doesn't
+  help. If the retry also fails, `ActiveRecord::ConnectionFailed` is raised.
+- **Timeouts and cancellations now raise distinct, Rails-standard error classes** instead of a
+  generic `ActiveRecord::ActiveRecordError`, so callers can `rescue` them the same way they
+  would for any other adapter:
+  - `ActiveRecord::StatementTimeout` - the server killed the query server-side, via
+    `max_execution_time` or `cancel_http_readonly_queries_on_client_close`.
+  - `ActiveRecord::AdapterTimeout` - the client gave up waiting for a response
+    (`Net::ReadTimeout`); the query may still be running server-side.
+  - `ActiveRecord::ConnectionFailed` - the connection-retry above was exhausted.
 
 ## Usage in Rails
 

--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'base64'
+require 'net/http'
 require 'clickhouse-activerecord/version'
 
 module ActiveRecord
@@ -11,6 +12,9 @@ module ActiveRecord
         HTTP_AUTH_BASIC = :basic
         HTTP_AUTH_X_HEADERS = :x_clickhouse_headers
         HTTP_AUTH_TYPES = [HTTP_AUTH_QUERY_PARAMS, HTTP_AUTH_BASIC, HTTP_AUTH_X_HEADERS].freeze
+
+        # Connection-level failures worth a single retry on a fresh connection.
+        RETRYABLE_CONNECTION_ERRORS = [Net::OpenTimeout, EOFError, Errno::ECONNRESET, IOError].freeze
 
         def with_settings(**settings)
           @block_settings ||= {}
@@ -84,19 +88,35 @@ module ActiveRecord
         end
 
         def internal_exec_query(sql, name = nil, binds = [], prepare: false, async: false, allow_retry: false)
-          result = execute(sql, name)
-          columns = result['meta'].map { |m| m['name'] }
-          types = {}
-          result['meta'].each_with_index do |m, i|
-            # need use column name and index after commit in 7.2:
-            # https://github.com/rails/rails/commit/24dbf7637b1d5cd6eb3d7100b8d0f6872c3fee3c
-            types[m['name']] = types[i] = type_map.lookup(m['type'])
+          connection_retries = 0
+          begin
+            result = execute(sql, name)
+            columns = result['meta'].map { |m| m['name'] }
+            types = {}
+            result['meta'].each_with_index do |m, i|
+              # need use column name and index after commit in 7.2:
+              # https://github.com/rails/rails/commit/24dbf7637b1d5cd6eb3d7100b8d0f6872c3fee3c
+              types[m['name']] = types[i] = type_map.lookup(m['type'])
+            end
+            ActiveRecord::Result.new(columns, result['data'], types)
+          rescue ActiveRecord::ActiveRecordError => e
+            raise e
+          rescue Net::ReadTimeout => e
+            raise ActiveRecord::AdapterTimeout, "Response: #{e.message}"
+          rescue *RETRYABLE_CONNECTION_ERRORS => e
+            raise ActiveRecord::ConnectionFailed, "Response: #{e.message}" if connection_retries.positive?
+
+            connection_retries += 1
+            logger&.warn("[clickhouse-activerecord] retrying read query after connection failure (#{e.class}: #{e.message})")
+            begin
+              reconnect
+            rescue StandardError
+              nil
+            end
+            retry
+          rescue StandardError => e
+            raise ActiveRecord::ActiveRecordError, "Response: #{e.message}"
           end
-          ActiveRecord::Result.new(columns, result['data'], types)
-        rescue ActiveRecord::ActiveRecordError => e
-          raise e
-        rescue StandardError => e
-          raise ActiveRecord::ActiveRecordError, "Response: #{e.message}"
         end
 
         def exec_insert_all(sql, name)

--- a/lib/active_record/connection_adapters/clickhouse/statement/response_processor.rb
+++ b/lib/active_record/connection_adapters/clickhouse/statement/response_processor.rb
@@ -54,7 +54,7 @@ module ActiveRecord
 
           # @return [String, Hash, Array]
           def process_successful_response
-            raise_generic!(@sql) if @body.include?('DB::Exception') && @body.match?(DB_EXCEPTION_REGEXP)
+            raise_database_error!(@sql) if @body.include?('DB::Exception') && @body.match?(DB_EXCEPTION_REGEXP)
 
             format_body_response
           end
@@ -103,14 +103,17 @@ module ActiveRecord
             JSON.parse(payload, decimal_class: BigDecimal)
           end
 
-          def raise_database_error!
+          def raise_database_error!(sql = nil)
             case @body
             when /DB::Exception:.*\(UNKNOWN_DATABASE\)/
               raise ActiveRecord::NoDatabaseError
             when /DB::Exception:.*\(DATABASE_ALREADY_EXISTS\)/
               raise ActiveRecord::DatabaseAlreadyExists
+            when /DB::Exception:.*\(TIMEOUT_EXCEEDED\)/
+              # server-side cancellation, vs. ActiveRecord::AdapterTimeout (client gave up)
+              raise ActiveRecord::StatementTimeout, "Response code: #{@raw_response.code}:\n#{@body}#{"\nQuery: #{sql}" if sql}"
             else
-              raise_generic!
+              raise_generic!(sql)
             end
           end
 

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -150,7 +150,9 @@ module ActiveRecord
             host: @config[:host] || 'localhost',
             port: port,
             ssl: @config[:ssl].present? ? @config[:ssl] : port == 443,
+            insecure: @config.fetch(:insecure, true),
             sslca: @config[:sslca],
+            open_timeout: @config[:open_timeout],
             read_timeout: @config[:read_timeout],
             write_timeout: @config[:write_timeout],
             keep_alive_timeout: @config[:keep_alive_timeout]
@@ -158,7 +160,13 @@ module ActiveRecord
         end
         @connection_parameters = connection
 
-        @connection_config = { user: @config[:username], password: @config[:password], database: @config[:database] }.compact
+        @connection_config = {
+          user: @config[:username],
+          password: @config[:password],
+          database: @config[:database],
+          max_execution_time: @config[:max_execution_time],
+          cancel_http_readonly_queries_on_client_close: @config[:cancel_http_readonly_queries_on_client_close],
+        }.compact
         @debug = @config[:debug] || false
         @default_response_format = @config[:format] || DEFAULT_RESPONSE_FORMAT
         @http_auth = @config[:http_auth]&.to_sym
@@ -227,12 +235,17 @@ module ActiveRecord
               case key
               when 'ssl'                then config[:ssl]                = (value == 'true')
               when 'debug'              then config[:debug]              = (value == 'true')
+              when 'insecure'           then config[:insecure]           = (value == 'true')
+              when 'open_timeout'       then config[:open_timeout]       = value.to_i
               when 'read_timeout'       then config[:read_timeout]       = value.to_i
               when 'write_timeout'      then config[:write_timeout]      = value.to_i
               when 'keep_alive_timeout' then config[:keep_alive_timeout] = value.to_i
               when 'http_auth'          then config[:http_auth]          = value
               when 'cluster_name'       then config[:cluster_name]       = value
               when 'sslca'              then config[:sslca]              = value
+              when 'max_execution_time' then config[:max_execution_time] = value.to_i
+              when 'cancel_http_readonly_queries_on_client_close'
+                config[:cancel_http_readonly_queries_on_client_close] = (value == 'true')
               end
             end
           end
@@ -607,9 +620,15 @@ module ActiveRecord
       private
 
       def connect
-        @connection = @connection_parameters[:connection] || Net::HTTP.start(@connection_parameters[:host], @connection_parameters[:port], use_ssl: @connection_parameters[:ssl], verify_mode: OpenSSL::SSL::VERIFY_NONE)
+        @connection = @connection_parameters[:connection] || Net::HTTP.start(
+          @connection_parameters[:host],
+          @connection_parameters[:port],
+          use_ssl: @connection_parameters[:ssl],
+          verify_mode: @connection_parameters[:insecure] ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER,
+          **{ open_timeout: @connection_parameters[:open_timeout] }.compact
+        )
 
-        @connection.ca_file = @connection_parameters[:ca_file] if @connection_parameters[:ca_file]
+        @connection.ca_file = @connection_parameters[:sslca] if @connection_parameters[:sslca]
         @connection.read_timeout = @connection_parameters[:read_timeout] if @connection_parameters[:read_timeout]
         @connection.write_timeout = @connection_parameters[:write_timeout] if @connection_parameters[:write_timeout]
 

--- a/spec/single/connection_hardening_spec.rb
+++ b/spec/single/connection_hardening_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Connection hardening' do
+  let(:http_connection) { instance_double(Net::HTTP) }
+  let(:success_body) { %(["result"]\n["UInt8"]\n[1]\n) }
+  let(:success_response) { instance_double(Net::HTTPResponse, code: '200', body: success_body) }
+
+  before do
+    allow(http_connection).to receive(:keep_alive_timeout=)
+    allow(http_connection).to receive(:read_timeout=)
+    allow(http_connection).to receive(:write_timeout=)
+    allow(http_connection).to receive(:ca_file=)
+    allow(http_connection).to receive(:started?).and_return(true)
+  end
+
+  describe 'connect' do
+    def net_http_start_args
+      args = nil
+      allow(Net::HTTP).to receive(:start) do |*a, **kw|
+        args = { args: a, kwargs: kw }
+        http_connection
+      end
+      ActiveRecord::Base.clickhouse_connection(config)
+      args
+    end
+
+    context 'without open_timeout configured' do
+      let(:config) { { adapter: 'clickhouse', host: 'localhost', database: 'db' } }
+
+      it 'does not pass open_timeout to Net::HTTP.start, preserving its own default' do
+        expect(net_http_start_args[:kwargs]).not_to have_key(:open_timeout)
+      end
+    end
+
+    context 'with open_timeout configured' do
+      let(:config) { { adapter: 'clickhouse', host: 'localhost', database: 'db', open_timeout: 5 } }
+
+      it 'passes it through to Net::HTTP.start' do
+        expect(net_http_start_args[:kwargs][:open_timeout]).to eq(5)
+      end
+    end
+
+    context 'by default' do
+      let(:config) { { adapter: 'clickhouse', host: 'localhost', database: 'db' } }
+
+      it 'does not verify the TLS certificate, matching prior behavior' do
+        expect(net_http_start_args[:kwargs][:verify_mode]).to eq(OpenSSL::SSL::VERIFY_NONE)
+      end
+    end
+
+    context 'with insecure: false' do
+      let(:config) { { adapter: 'clickhouse', host: 'localhost', database: 'db', insecure: false } }
+
+      it 'verifies the TLS certificate' do
+        expect(net_http_start_args[:kwargs][:verify_mode]).to eq(OpenSSL::SSL::VERIFY_PEER)
+      end
+    end
+
+    context 'with sslca configured' do
+      let(:config) { { adapter: 'clickhouse', host: 'localhost', database: 'db', sslca: '/path/to/ca.pem' } }
+
+      it 'sets ca_file on the connection' do
+        net_http_start_args
+        expect(http_connection).to have_received(:ca_file=).with('/path/to/ca.pem')
+      end
+    end
+  end
+
+  describe 'session settings' do
+    let(:config) do
+      {
+        adapter: 'clickhouse',
+        host: 'localhost',
+        database: 'db',
+        max_execution_time: 25,
+        cancel_http_readonly_queries_on_client_close: true
+      }
+    end
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    before { allow(Net::HTTP).to receive(:start).and_return(http_connection) }
+
+    it 'merges max_execution_time into the request params sent with every query' do
+      expect(adapter.instance_variable_get(:@connection_config)[:max_execution_time]).to eq(25)
+    end
+
+    it 'merges cancel_http_readonly_queries_on_client_close into the request params' do
+      expect(adapter.instance_variable_get(:@connection_config)[:cancel_http_readonly_queries_on_client_close]).to eq(true)
+    end
+  end
+
+  describe '#exec_query' do
+    let(:config) { { adapter: 'clickhouse', host: 'localhost', database: 'db' } }
+
+    subject(:adapter) { ActiveRecord::Base.clickhouse_connection(config) }
+
+    before { allow(Net::HTTP).to receive(:start).and_return(http_connection) }
+
+    context 'on a fast connection-level failure' do
+      it 'retries once on a fresh connection and succeeds' do
+        call_count = 0
+        allow(http_connection).to receive(:post) do
+          call_count += 1
+          call_count == 1 ? raise(Errno::ECONNRESET) : success_response
+        end
+
+        result = adapter.exec_query('SELECT 1')
+
+        expect(call_count).to eq(2)
+        expect(result.rows).to eq([[1]])
+      end
+
+      it 'only retries once, then raises ActiveRecord::ConnectionFailed' do
+        allow(http_connection).to receive(:post).and_raise(EOFError)
+
+        expect { adapter.exec_query('SELECT 1') }.to raise_error(ActiveRecord::ConnectionFailed)
+        expect(http_connection).to have_received(:post).twice
+      end
+    end
+
+    context 'on Net::ReadTimeout' do
+      it 'does not retry and raises ActiveRecord::AdapterTimeout instead' do
+        allow(http_connection).to receive(:post).and_raise(Net::ReadTimeout)
+
+        expect { adapter.exec_query('SELECT 1') }.to raise_error(ActiveRecord::AdapterTimeout)
+        expect(http_connection).to have_received(:post).once
+      end
+    end
+
+    context 'when the server cancels the query via max_execution_time' do
+      it 'raises ActiveRecord::StatementTimeout' do
+        response = instance_double(
+          Net::HTTPResponse,
+          code: '500',
+          body: 'Code: 159. DB::Exception: Timeout exceeded (TIMEOUT_EXCEEDED)'
+        )
+        allow(http_connection).to receive(:post).and_return(response)
+
+        expect { adapter.exec_query('SELECT 1') }.to raise_error(ActiveRecord::StatementTimeout)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Hardens the HTTP connection this gem opens to ClickHouse against a few failure modes that
currently have no config knob, plus a couple of small bug fixes found along the way. No default
behavior changes - everything here is either additive config or a fix to something that was
already broken/inert.

- **`open_timeout`** (new config key): bounds how long establishing the underlying TCP
  connection is allowed to take. Unlike `read_timeout`/`write_timeout`, which only apply once a
  connection exists, there was previously no way to bound a dead network path that never
  completes the TCP handshake - it fell back to `Net::HTTP`'s own default. Unset by default, so
  existing behavior is unchanged unless you opt in.
- **TLS verification is now configurable** (`insecure`, new config key, defaults to `true`).
  Every connection has always been made with `verify_mode: OpenSSL::SSL::VERIFY_NONE`, so an SSL
  connection to ClickHouse never actually checked the server's certificate. That stays the
  default here to avoid breaking anyone relying on it (self-signed/internal certs with no CA
  configured); set `insecure: false` to turn verification on.
- **Bug fix: `sslca` was silently dead.** It's parsed into config and even threaded through to
  `@connection_parameters[:sslca]`, but `connect` read `@connection_parameters[:ca_file]` - a key
  that's never set anywhere - so a configured CA bundle was never actually applied. Fixed to read
  `:sslca`.
- **Read queries retry once** on a fresh connection when the failure happens before the server
  responds at all (`Net::OpenTimeout`, `EOFError`, `ECONNRESET`, `IOError`) - the kind of failure
  a stale pooled connection produces. Writes are untouched (structurally they never go through
  `internal_exec_query`), and `Net::ReadTimeout` is deliberately **not** retried on any query -
  the server already has the query and is working it, so re-sending just adds load.
- **`max_execution_time` / `cancel_http_readonly_queries_on_client_close`** (new config keys):
  merged into the session settings sent with every request, so a server-side query time limit
  can be configured once instead of via a raw SQL `SETTINGS` clause on every query. These keys
  were not new to the config-parsing code, but there was nowhere they got applied.
- **Timeouts/cancellations now raise Rails-standard error classes** instead of a generic
  `ActiveRecord::ActiveRecordError`, reusing existing Rails core classes (matching how this gem
  already reuses `ActiveRecord::NoDatabaseError`/`DatabaseAlreadyExists`):
  - `ActiveRecord::StatementTimeout` - server-side cancellation (`max_execution_time` /
    `cancel_http_readonly_queries_on_client_close`).
  - `ActiveRecord::AdapterTimeout` - client gave up waiting (`Net::ReadTimeout`); the query may
    still be running server-side.
  - `ActiveRecord::ConnectionFailed` - the connection retry above was exhausted.

All new config keys (`open_timeout`, `insecure`, `max_execution_time`,
`cancel_http_readonly_queries_on_client_close`) are also supported as `clickhouse://` URL query
params, matching the existing `read_timeout`/`write_timeout`/etc. convention.

## Why

We hit this in production: requests to a ClickHouse-backed view intermittently hung the full
28s Heroku rack-timeout and 500'd. Root cause was two failure modes this gem gives no config
hook for - a dead TCP path with no `open_timeout`, and no server-side query cancellation to stop
a runaway query from continuing to burn resources after the client gave up. We initially worked
around it with an app-side `prepend` patch, then figured it was worth upstreaming properly
instead of every consumer of this gem carrying the same patch.

## Testing

New spec file `spec/single/connection_hardening_spec.rb`, mocking `Net::HTTP` the same way the
existing `spec/single/url_config_spec.rb` does (no live ClickHouse needed) - covers `connect`'s
`open_timeout`/`verify_mode`/`sslca` wiring, the session-settings merge, and
`exec_query`'s retry/timeout/cancellation behavior. All existing specs pass unchanged.

## Checklist

- [x] Ran `bundle exec rspec spec/single` (the specs that don't require a live ClickHouse -
      `url_config_spec.rb`, `http_auth_spec.rb`, `connection_hardening_spec.rb`)
- [x] README updated with the new config keys and a "Connection hardening" section
- [ ] CHANGELOG.md - left to the maintainer, since entries there are versioned at release time
