### PR TITLE
Order structure dump by a dependency graph

### DIFF
--- a/lib/clickhouse-activerecord/structure_dumper.rb
+++ b/lib/clickhouse-activerecord/structure_dumper.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+module ClickhouseActiverecord
+  # Builds the ordered list of `CREATE` statements that makes up `structure.sql`.
+  #
+  # Rails 8 prepares an empty database by loading `structure.sql` instead of
+  # replaying every migration, so the file has to be replayable top to bottom.
+  # ClickHouse resolves a view's query when the view is created and refuses to
+  # create a materialized view whose `TO` target is missing, which a dump grouped
+  # by kind and sorted by name only satisfies by luck. Statements are therefore
+  # ordered by a dependency graph built from `system.tables` metadata and from
+  # the `CREATE` statements themselves.
+  class StructureDumper
+    Definition = Struct.new(:name, :kind, :sql, :dependencies, keyword_init: true)
+
+    KIND_RANK = %i[function table dictionary view materialized_view].freeze
+
+    KIND_PATTERNS = {
+      materialized_view: /\ACREATE\s+(?:OR\s+REPLACE\s+)?MATERIALIZED\s+VIEW\b/i,
+      view: /\ACREATE\s+(?:OR\s+REPLACE\s+)?(?:LIVE\s+|WINDOW\s+)?VIEW\b/i,
+      dictionary: /\ACREATE\s+(?:OR\s+REPLACE\s+)?DICTIONARY\b/i
+    }.freeze
+
+    NAME = /(?:`[^`]+`|[A-Za-z_]\w*)/
+    QUALIFIED_NAME = /(?:(#{NAME})\.)?(#{NAME})/
+
+    # Table functions (`FROM numbers(10)`) and `ARRAY JOIN`, whose operand is a
+    # column rather than a table, are left out.
+    FROM_OR_JOIN = /\b(?:FROM|(?<!ARRAY\s)JOIN)\s+#{QUALIFIED_NAME}(?!\s*\()/i
+    MATERIALIZED_TARGET = /\ACREATE\s+MATERIALIZED\s+VIEW\s+#{QUALIFIED_NAME}(?:\s+UUID\s+'[^']*')?\s+TO\s+#{QUALIFIED_NAME}/i
+    BUFFER_ENGINE = /\bENGINE\s*=\s*Buffer\s*\(\s*'?(#{NAME})'?\s*,\s*'?(#{NAME})'?/i
+    DICTIONARY_ENGINE = /\bENGINE\s*=\s*Dictionary\s*\(\s*'?#{QUALIFIED_NAME}'?\s*\)/i
+
+    def initialize(connection, database)
+      @connection = connection
+      @database = database
+    end
+
+    def dump(path)
+      File.open(path, 'w:utf-8') do |file|
+        statements.each { |sql| file.puts "#{sql};\n\n" }
+      end
+    end
+
+    def statements
+      (order(function_definitions) + order(table_definitions)).map(&:sql)
+    end
+
+    private
+
+    def function_definitions
+      rows = @connection.execute(<<~SQL)['data']
+        SELECT name, create_query FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name
+      SQL
+
+      definitions = rows.map do |name, create_query|
+        Definition.new(name: name, kind: :function, sql: create_query.gsub('\\n', "\n"), dependencies: Set.new)
+      end
+
+      names = definitions.map(&:name)
+      definitions.each do |definition|
+        calls = names.select { |name| name != definition.name && definition.sql.match?(/\b#{Regexp.escape(name)}\s*\(/) }
+        definition.dependencies = Set.new(calls)
+      end
+
+      definitions
+    end
+
+    def table_definitions
+      rows = table_rows
+      names = Set.new(rows.map(&:first))
+
+      definitions = rows.map do |name, *|
+        sql = @connection.show_create_table(name, single_line: false).gsub("#{@database}.", '')
+        Definition.new(name: name, kind: kind_of(sql), sql: sql, dependencies: Set.new)
+      end
+      by_name = definitions.index_by(&:name)
+
+      definitions.each do |definition|
+        references(definition.sql).each do |reference|
+          definition.dependencies << reference if names.include?(reference) && reference != definition.name
+        end
+      end
+
+      rows.each do |name, loading_databases, loading_tables, dependent_databases, dependent_tables|
+        loading_databases.zip(loading_tables).each do |database, table|
+          next unless database == @database && names.include?(table) && table != name
+
+          by_name[name].dependencies << table
+        end
+
+        # `dependencies_*` points the other way: those objects select from `name`.
+        dependent_databases.zip(dependent_tables).each do |database, table|
+          next unless database == @database && names.include?(table) && table != name
+
+          by_name[table].dependencies << name
+        end
+      end
+
+      definitions
+    end
+
+    def table_rows
+      @connection.execute(<<~SQL)['data']
+        SELECT
+          name,
+          loading_dependencies_database,
+          loading_dependencies_table,
+          dependencies_database,
+          dependencies_table
+        FROM system.tables
+        WHERE database = #{@connection.quote(@database)} AND name NOT LIKE '.inner_id.%'
+        ORDER BY name
+      SQL
+    rescue ActiveRecord::StatementInvalid
+      # `loading_dependencies_*` were added in ClickHouse 22.4.
+      @connection.execute(<<~SQL)['data'].map { |name, *dependencies| [name, [], [], *dependencies] }
+        SELECT name, dependencies_database, dependencies_table
+        FROM system.tables
+        WHERE database = #{@connection.quote(@database)} AND name NOT LIKE '.inner_id.%'
+        ORDER BY name
+      SQL
+    end
+
+    def order(definitions)
+      pending = definitions.sort_by { |definition| [KIND_RANK.index(definition.kind), definition.name] }
+      emitted = Set.new
+      ordered = []
+
+      until pending.empty?
+        ready, pending = pending.partition { |definition| definition.dependencies.subset?(emitted) }
+
+        # Nothing is ready only when the definitions left depend on each other. A
+        # cyclic schema has no replayable order, so emit the first one and move
+        # on rather than loop forever.
+        ready, pending = [pending.first], pending.drop(1) if ready.empty?
+
+        ordered.concat(ready)
+        emitted.merge(ready.map(&:name))
+      end
+
+      ordered
+    end
+
+    def kind_of(sql)
+      KIND_PATTERNS.find { |_kind, pattern| sql.match?(pattern) }&.first || :table
+    end
+
+    def references(sql)
+      [
+        scan(sql, FROM_OR_JOIN).map { |match| qualified_name(match, 1) },
+        scan(sql, MATERIALIZED_TARGET).map { |match| qualified_name(match, 3) },
+        scan(sql, BUFFER_ENGINE).map { |match| qualified_name(match, 1) },
+        scan(sql, DICTIONARY_ENGINE).map { |match| qualified_name(match, 1) }
+      ].flatten.compact
+    end
+
+    def scan(sql, regexp)
+      sql.to_enum(:scan, regexp).map { Regexp.last_match }
+    end
+
+    def qualified_name(match, index)
+      database = match[index]
+      return if database && unquote(database) != @database
+
+      unquote(match[index + 1])
+    end
+
+    def unquote(name)
+      name.start_with?('`') ? name[1..-2] : name
+    end
+  end
+end

--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'clickhouse-activerecord/structure_dumper'
+
 module ClickhouseActiverecord
   class Tasks
     delegate :connection, :establish_connection, to: ActiveRecord::Base
@@ -37,31 +39,7 @@ module ClickhouseActiverecord
     def structure_dump(path, *)
       establish_master_connection
 
-      # get all functions
-      functions = connection.execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name")['data']
-                            .flatten
-                            .map { |function| function.gsub('\\n', "\n") }
-
-      # get all tables
-      table_defs = connection.execute("SHOW TABLES FROM #{@configuration.database} WHERE name NOT LIKE '.inner_id.%'")['data']
-                             .flatten
-                             .map { |name| connection.show_create_table(name, single_line: false).gsub("#{@configuration.database}.", '') }
-
-      # separate views from tables
-      views, tables = table_defs.partition { |sql| sql.match(/^CREATE\s+(MATERIALIZED\s+)?VIEW/) }
-
-      # separate materialized from regular views
-      mat_views, views = views.partition { |sql| sql.match(/^CREATE\s+MATERIALIZED\s+VIEW/) }
-
-      # sort: UDFs -> materialized views -> tables -> views
-      ordered_definitions = functions.sort + mat_views.sort + tables.sort + views.sort
-
-      # puts to file
-      File.open(path, 'w:utf-8') do |file|
-        ordered_definitions.each do |sql|
-          file.puts "#{sql};\n\n"
-        end
-      end
+      StructureDumper.new(connection, @configuration.database).dump(path)
     end
 
     def structure_load(*args)

--- a/spec/single/structure_dump_spec.rb
+++ b/spec/single/structure_dump_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'clickhouse-activerecord/tasks'
+require 'tempfile'
+require 'timeout'
+
+RSpec.describe ClickhouseActiverecord::StructureDumper, :migrations do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:db_config) { ActiveRecord::Base.connection_db_config }
+  let(:database) { db_config.configuration_hash[:database] }
+
+  # Names run backwards through the dependencies, so ordering by name - or by
+  # kind and then by name - places every object before the ones it needs.
+  let(:schema) do
+    [
+      'CREATE TABLE z_events (id UInt64, date Date, value UInt64) ENGINE = MergeTree ORDER BY (date, id)',
+      'CREATE TABLE y_totals (date Date, total UInt64) ENGINE = SummingMergeTree ORDER BY date',
+      'CREATE MATERIALIZED VIEW x_totals_mv TO y_totals AS SELECT date, sum(value) AS total FROM z_events GROUP BY date',
+      'CREATE VIEW w_totals_view AS SELECT * FROM y_totals',
+      'CREATE VIEW v_joined_view AS SELECT t.date AS date, e.id AS id FROM w_totals_view AS t INNER JOIN z_events AS e ON t.date = e.date',
+      'CREATE MATERIALIZED VIEW u_ids_mv ENGINE = AggregatingMergeTree ORDER BY date AS SELECT date, uniqState(id) AS ids FROM v_joined_view GROUP BY date'
+    ]
+  end
+
+  let(:dependencies) do
+    {
+      'x_totals_mv' => %w[y_totals z_events],
+      'w_totals_view' => %w[y_totals],
+      'v_joined_view' => %w[w_totals_view z_events],
+      'u_ids_mv' => %w[v_joined_view]
+    }
+  end
+
+  before { schema.each { |sql| connection.execute(sql) } }
+
+  def schema_names
+    dependencies.keys | %w[z_events y_totals]
+  end
+
+  def dumped_names(dumper = described_class.new(connection, database))
+    dumper.statements.map { |sql| sql[/\ACREATE\s+(?:MATERIALIZED\s+VIEW|VIEW|DICTIONARY|TABLE|FUNCTION)\s+(\S+)/i, 1] }
+  end
+
+  it 'dumps every object after the objects it depends on' do
+    names = dumped_names
+
+    aggregate_failures do
+      dependencies.each do |name, required|
+        required.each do |dependency|
+          expect(names.index(dependency)).to be < names.index(name),
+                                             "expected #{dependency} before #{name}, got #{names.inspect}"
+        end
+      end
+    end
+  end
+
+  it 'writes a structure file an empty database can be created from' do
+    file = Tempfile.new(['structure', '.sql'])
+    target = ActiveRecord::DatabaseConfigurations::HashConfig.new(
+      db_config.env_name, db_config.name, db_config.configuration_hash.merge(database: "#{database}_structure_dump_spec")
+    )
+
+    ClickhouseActiverecord::Tasks.new(db_config).structure_dump(file.path)
+
+    tasks = ClickhouseActiverecord::Tasks.new(target)
+
+    begin
+      tasks.create
+      tasks.structure_load(file.path)
+      expect(ActiveRecord::Base.connection.tables).to include(*schema_names)
+    ensure
+      tasks.drop
+      ActiveRecord::Base.establish_connection(:default)
+      file.close!
+    end
+  end
+
+  context 'with user defined functions' do
+    before do
+      connection.drop_functions
+      connection.execute('CREATE FUNCTION z_base_fun AS (x) -> x + 1')
+      connection.execute('CREATE FUNCTION a_derived_fun AS (x) -> z_base_fun(x) * 2')
+    end
+
+    after { connection.drop_functions }
+
+    it 'dumps functions before any table, and after the functions they call' do
+      expect(dumped_names.first(2)).to eq(%w[z_base_fun a_derived_fun])
+    end
+  end
+
+  it 'dumps every object even when the dependency graph has a cycle' do
+    # ClickHouse rejects a genuine cycle, but a column carrying the name of a
+    # table can still close one in the graph.
+    cyclic = instance_double(ActiveRecord::ConnectionAdapters::ClickhouseAdapter)
+    allow(cyclic).to receive(:quote) { |value| "'#{value}'" }
+    allow(cyclic).to receive(:execute) do |sql|
+      { 'data' => sql.include?('system.functions') ? [] : [['a_view', [], [], [], []], ['b_view', [], [], [], []]] }
+    end
+    allow(cyclic).to receive(:show_create_table) do |name, **|
+      other = name == 'a_view' ? 'b_view' : 'a_view'
+      "CREATE VIEW #{name} AS SELECT * FROM #{other}"
+    end
+
+    names = Timeout.timeout(10) { dumped_names(described_class.new(cyclic, database)) }
+
+    expect(names).to contain_exactly('a_view', 'b_view')
+  end
+end


### PR DESCRIPTION
Rails 8 prepares an empty database by loading structure.sql instead of replaying every migration, so the file has to be replayable top to bottom. The dump grouped objects by kind and sorted each group by name, which only produces a loadable file by luck: a materialized view came before the table it selects from and before its TO target, and a view came after the views reading from it.

Extract the dump into StructureDumper, which topologically sorts the statements over a dependency graph. No single source of edges is complete, so three are combined:

  * system.tables.loading_dependencies_* for dictionaries and the tables reading from them
  * system.tables.dependencies_*, which points the other way, for the source tables of materialized views
  * the CREATE statements themselves for plain views, for materialized view TO targets - ClickHouse reports neither as a dependency anywhere - and for the Buffer and Dictionary engines

Independent objects keep their kind and name order so the file stays diff-friendly, and a cycle in the graph emits its definitions rather than looping forever.