### PR TITLE
Round-trip Float64 columns through the schema dumper

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/table_definition.rb
+++ b/lib/active_record/connection_adapters/clickhouse/table_definition.rb
@@ -63,6 +63,12 @@ module ActiveRecord
           args.each { |name| column(name, kind, **options.except(:limit, :unsigned)) }
         end
 
+        def float(*args, **options)
+          kind = options[:limit] == 8 ? :float64 : :float
+
+          args.each { |name| column(name, kind, **options.except(:limit)) }
+        end
+
         def datetime(*args, **options)
           kind = :datetime
 

--- a/lib/active_record/connection_adapters/clickhouse_adapter.rb
+++ b/lib/active_record/connection_adapters/clickhouse_adapter.rb
@@ -103,6 +103,7 @@ module ActiveRecord
         integer: { name: 'UInt32' },
         big_integer: { name: 'UInt64' },
         float: { name: 'Float32' },
+        float64: { name: 'Float64' },
         decimal: { name: 'Decimal' },
         datetime: { name: 'DateTime' },
         datetime64: { name: 'DateTime64' },
@@ -212,6 +213,14 @@ module ActiveRecord
         !native_database_types[type].nil?
       end
 
+      # Rails appends the limit to the native type name (e.g. "Float32(8)"), which is not valid in ClickHouse.
+      # Resolve the float width by limit here so that add_column / change_column behave like TableDefinition#float.
+      def type_to_sql(type, limit: nil, precision: nil, scale: nil, **)
+        return native_database_types[limit == 8 ? :float64 : :float][:name] if type.to_s == 'float'
+
+        super
+      end
+
       def supports_indexes_in_create?
         true
       end
@@ -267,6 +276,10 @@ module ActiveRecord
               8
             when /(Nullable)?\(?U?Int128\)?/
               16
+            when /(Nullable)?\(?Float32\)?/
+              nil
+            when /(Nullable)?\(?Float64\)?/
+              8
             else
               super
           end

--- a/lib/clickhouse-activerecord/schema_dumper.rb
+++ b/lib/clickhouse-activerecord/schema_dumper.rb
@@ -154,11 +154,6 @@ module ClickhouseActiverecord
       end
     end
 
-    def schema_limit(column)
-      return nil if column.type == :float
-      super
-    end
-
     def schema_unsigned(column)
       return nil unless column.type == :integer && !simple
       (column.sql_type =~ /(Nullable)?\(?UInt\d+\)?/).nil? ? false : nil

--- a/spec/fixtures/migrations/dsl_add_float64_column/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_add_float64_column/1_create_some_table.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CreateSomeTable < ActiveRecord::Migration[7.1]
+  def up
+    create_table :some, options: 'MergeTree PARTITION BY toYYYYMM(date) ORDER BY (date)' do |t|
+      t.date :date, null: false
+    end
+  end
+end
+

--- a/spec/fixtures/migrations/dsl_add_float64_column/2_modify_some_table.rb
+++ b/spec/fixtures/migrations/dsl_add_float64_column/2_modify_some_table.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ModifySomeTable < ActiveRecord::Migration[7.1]
+  def up
+    add_column :some, :float32, :float, null: false, default: 0
+    add_column :some, :float64, :float, limit: 8, null: false, default: 0
+  end
+end

--- a/spec/fixtures/migrations/dsl_table_with_float_creation/1_create_some_table.rb
+++ b/spec/fixtures/migrations/dsl_table_with_float_creation/1_create_some_table.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateSomeTable < ActiveRecord::Migration[7.1]
+  def up
+    create_table :some, id: false do |t|
+      t.float :default_float
+      t.float :float32, limit: 4, null: false, default: 0
+      t.float :float64, limit: 8, null: false, default: 0
+      t.float :nullable_float64, limit: 8
+    end
+  end
+end

--- a/spec/single/migration_spec.rb
+++ b/spec/single/migration_spec.rb
@@ -116,6 +116,31 @@ RSpec.describe 'Migration', :migrations do
             end
           end
 
+          context 'float' do
+            let(:directory) { 'dsl_table_with_float_creation' }
+            it 'resolves the width by limit and keeps it in the schema dump' do
+              subject
+
+              current_schema = schema(model)
+
+              expect(current_schema['default_float'].sql_type).to eq('Nullable(Float32)')
+              expect(current_schema['float32'].sql_type).to eq('Float32')
+              expect(current_schema['float64'].sql_type).to eq('Float64')
+              expect(current_schema['nullable_float64'].sql_type).to eq('Nullable(Float64)')
+
+              require 'clickhouse-activerecord/schema_dumper'
+
+              dumped = StringIO.new
+              ClickhouseActiverecord::SchemaDumper.dump(ActiveRecord::Base.connection, dumped)
+
+              expect(dumped.string).to include('t.float "default_float"')
+              expect(dumped.string).not_to include('t.float "default_float", limit')
+              expect(dumped.string).to include('t.float "float32", default: 0.0, null: false')
+              expect(dumped.string).to include('t.float "float64", limit: 8, default: 0.0, null: false')
+              expect(dumped.string).to include('t.float "nullable_float64", limit: 8')
+            end
+          end
+
           context 'decimal' do
             let(:directory) { 'dsl_table_with_decimal_creation' }
             it 'creates a table with valid scale and precision' do
@@ -394,6 +419,18 @@ RSpec.describe 'Migration', :migrations do
         expect(current_schema['id'].sql_type).to eq('UInt32')
         expect(current_schema['date'].sql_type).to eq('Date')
         expect(current_schema['new_column'].sql_type).to eq('Nullable(UInt64)')
+      end
+    end
+
+    describe 'add float column' do
+      let(:directory) { 'dsl_add_float64_column' }
+      it 'resolves the width by limit' do
+        subject
+
+        current_schema = schema(model)
+
+        expect(current_schema['float32'].sql_type).to eq('Float32')
+        expect(current_schema['float64'].sql_type).to eq('Float64')
       end
     end
 


### PR DESCRIPTION
Closes #268

## Problem

`Float64` columns are dumped as `t.float "name"`, and `t.float` always maps to `Float32`, so a database built from `db/schema.rb` (e.g. CI via `db:setup`) gets a narrower column than one built by running migrations. There is also no DSL to declare `Float64`: `t.float :x, limit: 8` silently ignores the limit.

## Fix

Mirror the existing integer handling so the width travels with `limit`, the same way `t.integer "id", limit: 8` ⇄ `Int64` already does:

- `NATIVE_DATABASE_TYPES`: add `float64: { name: 'Float64' }` (`float` stays `Float32`, so existing schemas are unaffected)
- `Clickhouse::TableDefinition#float`: route `limit: 8` to `:float64` (same shape as `#integer`)
- `ClickhouseAdapter#type_to_sql`: resolve `:float` + `limit: 8` to `Float64`, so `add_column` / `change_column` don't produce `Float32(8)` (Rails' default appends the limit to the type name)
- `ClickhouseAdapter.extract_limit`: `Float32` → `nil`, `Float64` → `8`. With that in place the dumper's float-specific `schema_limit` override (which returned `nil` to hide the bogus `limit: 0` that `Nullable(Float32)` used to produce) is no longer needed, and the generic implementation writes `t.float "x", limit: 8` only for `Float64`

Result:

```ruby
t.float :f32                 # Float32          -> dumped as t.float "f32"
t.float :f64, limit: 8       # Float64          -> dumped as t.float "f64", limit: 8
t.float :nf64, limit: 8, null: true  # Nullable(Float64) -> t.float "nf64", limit: 8
```

## Tests

- `dsl_table_with_float_creation` fixture + `types / float` context: asserts the created `sql_type` for default / `limit: 4` / `limit: 8` / nullable, and that the schema dump contains `limit: 8` only for the `Float64` columns
- `dsl_add_float64_column` fixture + `add float column` describe: `add_column ... :float, limit: 8` creates `Float64`

`spec/single` on ClickHouse 26.6: 206 examples, 3 failures — the 3 failures are the pre-existing `with index` examples that also fail on current `master` against this ClickHouse version (index expression is now reported as `((int1 * int2, date))`), unrelated to this change.
